### PR TITLE
Fix silent empty results: refresh doc_ids and parse listing detail from its own JSON node

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Get full details for a specific listing.
 |-----------|------|----------|-------------|
 | `listing_id` | string | yes | Marketplace listing ID |
 
+### `search_location`
+Look up a city/town to get coordinates for `search_listings`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | yes | City, neighborhood, or ZIP (e.g. `Sarasota`, `Brooklyn NY`) |
+
 ### `monitor_search`
 Save a search as a monitor to track new listings over time.
 
@@ -94,11 +101,16 @@ List all saved monitors.
 ### `delete_monitor`
 Delete a saved monitor.
 
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | yes | Monitor name (note: `check_monitors` uses `monitor_name`) |
+
 ## Configuration
 
 | Env Variable | Default | Description |
 |-------------|---------|-------------|
 | `CHROME_PROFILE` | `Default` | Chrome profile directory name |
+| `FB_MCP_DEBUG` | unset | Set to `1` to log whether listing data was matched in the page |
 
 ## Updating GraphQL Queries
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Delete a saved monitor.
 | Env Variable | Default | Description |
 |-------------|---------|-------------|
 | `CHROME_PROFILE` | `Default` | Chrome profile directory name |
-| `FB_MCP_DEBUG` | unset | Set to `1` to log whether listing data was matched in the page |
 
 ## Updating GraphQL Queries
 
@@ -123,6 +122,29 @@ npm run capture-queries
 ```
 
 This opens a browser, navigates Marketplace, and captures current query IDs. Update `src/facebook/queries.ts` with the new values.
+
+Note that `capture-queries` launches Playwright against your real Chrome profile
+directory, so Chrome must be fully quit first or it will fail to launch.
+
+You can also capture them by hand without Playwright: open Marketplace in Chrome,
+run this in the DevTools console, then scroll the results to trigger a fetch.
+
+```js
+const rec = b => { const p = new URLSearchParams(b); const d = p.get('doc_id');
+  if (d) console.log(p.get('fb_api_req_friendly_name'), d); };
+const of = window.fetch;
+window.fetch = function (...a) {
+  const u = typeof a[0] === 'string' ? a[0] : a[0]?.url ?? '';
+  if (u.includes('/api/graphql') && typeof a[1]?.body === 'string') rec(a[1].body);
+  return of.apply(this, a);
+};
+```
+
+The two IDs this server needs are `CometMarketplaceSearchContentPaginationQuery`
+(search) and `MarketplaceSearchAddressDataSourceQuery` (location lookup).
+
+If results come back empty after a Facebook deploy, run with `FB_MCP_DEBUG=1` to
+see whether listing data is being matched in the page.
 
 ## Rate Limiting
 

--- a/src/facebook/client.ts
+++ b/src/facebook/client.ts
@@ -248,9 +248,10 @@ export class FacebookClient {
   }
 
   async searchLocation(
-    query: string
+    query: string,
+    viewerCoordinates?: { latitude: number; longitude: number }
   ): Promise<Array<{ name: string; latitude: number; longitude: number }>> {
-    const variables = buildLocationSearchVariables(query);
+    const variables = buildLocationSearchVariables(query, viewerCoordinates);
     const data = await this.graphqlRequest(LOCATION_SEARCH_DOC_ID, variables);
 
     try {

--- a/src/facebook/parser.ts
+++ b/src/facebook/parser.ts
@@ -4,12 +4,43 @@ import type {
   SearchResult,
 } from "./types.js";
 
+/**
+ * Locate the connection holding marketplace listings.
+ *
+ * Facebook moves this container between deploys (marketplace_search.feed_units,
+ * viewer.marketplace_feed_stories, ...), so rather than hardcoding one path we
+ * walk the response for the first `edges` array whose nodes carry a listing.
+ */
+function findListingConnection(root: any): any | null {
+  const seen = new Set<any>();
+  const queue: any[] = [root];
+
+  while (queue.length) {
+    const cur = queue.shift();
+    if (!cur || typeof cur !== "object" || seen.has(cur)) continue;
+    seen.add(cur);
+
+    if (Array.isArray(cur.edges)) {
+      const hasListing = cur.edges.some(
+        (e: any) => e?.node?.listing ?? e?.node?.marketplace_listing_title
+      );
+      if (hasListing) return cur;
+    }
+
+    for (const value of Object.values(cur)) {
+      if (value && typeof value === "object") queue.push(value);
+    }
+  }
+
+  return null;
+}
+
 export function parseSearchResponse(data: unknown): SearchResult {
   try {
     const root = data as any;
     const feedUnits =
       root?.data?.marketplace_search?.feed_units ??
-      root?.data?.marketplace_search?.feed_units;
+      findListingConnection(root?.data);
 
     if (!feedUnits) {
       return { listings: [], hasNextPage: false, endCursor: null };
@@ -20,8 +51,10 @@ export function parseSearchResponse(data: unknown): SearchResult {
 
     const listings: MarketplaceListing[] = edges
       .map((edge: any) => {
-        const listing = edge?.node?.listing;
-        if (!listing) return null;
+        // Some feed shapes nest the listing under `node.listing`, others put
+        // the listing fields directly on the node.
+        const listing = edge?.node?.listing ?? edge?.node;
+        if (!listing?.marketplace_listing_title && !listing?.id) return null;
 
         return {
           id: listing.id ?? "",
@@ -55,6 +88,84 @@ export function parseSearchResponse(data: unknown): SearchResult {
   }
 }
 
+/**
+ * Pull the listing's own object out of the relay payloads embedded in the page.
+ *
+ * The page carries data for many listings (suggestions, related items), so a
+ * bare regex over the whole document reliably picks up the wrong one. Instead
+ * we parse each embedded JSON block and walk it for the node whose `id` matches
+ * the listing we asked for.
+ */
+/** Fill gaps in `target` from `source` without overwriting values already set. */
+function mergeInto(target: any, source: any): any {
+  for (const [key, value] of Object.entries(source)) {
+    if (value === null || value === undefined) continue;
+    const existing = target[key];
+    if (
+      existing &&
+      typeof existing === "object" &&
+      typeof value === "object" &&
+      !Array.isArray(existing) &&
+      !Array.isArray(value)
+    ) {
+      mergeInto(existing, value);
+    } else if (
+      existing === undefined ||
+      existing === null ||
+      existing === "" ||
+      (Array.isArray(existing) && existing.length === 0)
+    ) {
+      target[key] = value;
+    }
+  }
+  return target;
+}
+
+function findListingNodeInHtml(html: string, listingId: string): any | null {
+  const blocks = html.matchAll(
+    /<script[^>]+type="application\/json"[^>]*>(.*?)<\/script>/gs
+  );
+
+  // Relay splits one listing across several partial nodes that share the same
+  // id (one carries the title, another the price, another the seller...), so
+  // collect every node for this id and merge them into a single object.
+  const merged: any = {};
+  let matched = false;
+  let fallback: any = null;
+
+  for (const block of blocks) {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(block[1]);
+    } catch {
+      continue;
+    }
+
+    const seen = new Set<any>();
+    const queue: any[] = [payload];
+
+    while (queue.length) {
+      const cur = queue.shift();
+      if (!cur || typeof cur !== "object" || seen.has(cur)) continue;
+      seen.add(cur);
+
+      if (String(cur.id) === String(listingId)) {
+        mergeInto(merged, cur);
+        matched = true;
+      } else if (!fallback && cur.marketplace_listing_title !== undefined) {
+        // Keep the first complete-looking listing as a last resort.
+        fallback = cur;
+      }
+
+      for (const value of Object.values(cur)) {
+        if (value && typeof value === "object") queue.push(value);
+      }
+    }
+  }
+
+  return matched ? merged : fallback;
+}
+
 export function parseListingDetailFromPage(
   html: string,
   listingId: string
@@ -78,21 +189,72 @@ export function parseListingDetailFromPage(
     seller: { name: "", profileUrl: "" },
   };
 
+  // Prefer the listing's own embedded JSON node — the regex fallbacks below
+  // match the first hit anywhere in the page, which is often a different
+  // (suggested/related) listing.
+  const node = findListingNodeInHtml(html, listingId);
+  // Set FB_MCP_DEBUG=1 to see what was matched when Facebook changes the page
+  // shape and fields start coming back empty.
+  if (process.env.FB_MCP_DEBUG) {
+    console.error(
+      `[fb-mcp] listing ${listingId}: ` +
+        (node
+          ? `matched id=${node.id} fields=${Object.keys(node).length}`
+          : "no embedded node found")
+    );
+  }
+  if (node) {
+    detail.title = node.marketplace_listing_title ?? "";
+    detail.price =
+      node.listing_price?.formatted_amount_zeros_stripped ??
+      node.listing_price?.formatted_amount ??
+      (node.listing_price?.amount != null
+        ? String(node.listing_price.amount)
+        : "");
+    detail.location =
+      node.location_text?.text ??
+      node.location?.reverse_geocode?.city_page?.display_name ??
+      node.location?.reverse_geocode?.city ??
+      "";
+    detail.description =
+      node.redacted_description?.text ?? node.description?.text ?? "";
+    detail.sellerName = node.marketplace_listing_seller?.name ?? "";
+    detail.seller.name = detail.sellerName;
+    if (node.marketplace_listing_seller?.id) {
+      detail.seller.profileUrl = `https://www.facebook.com/${node.marketplace_listing_seller.id}`;
+    }
+    detail.condition = node.condition ?? node.condition_text ?? "";
+    detail.isPending = node.is_pending ?? false;
+    if (node.creation_time) {
+      detail.postedDate = new Date(node.creation_time * 1000).toISOString();
+    }
+    const primary = node.primary_listing_photo?.image?.uri;
+    if (primary) {
+      detail.imageUrl = primary;
+      detail.images.push(primary);
+    }
+    for (const photo of node.listing_photos ?? []) {
+      const uri = photo?.image?.uri;
+      if (uri && !detail.images.includes(uri)) detail.images.push(uri);
+    }
+  }
+
   // Try to extract from meta tags first (most reliable)
   const titleMatch = html.match(
     /<meta\s+property="og:title"\s+content="([^"]*)"/
   );
-  if (titleMatch) detail.title = decodeHtmlEntities(titleMatch[1]);
+  if (!detail.title && titleMatch) detail.title = decodeHtmlEntities(titleMatch[1]);
 
   const descMatch = html.match(
     /<meta\s+property="og:description"\s+content="([^"]*)"/
   );
-  if (descMatch) detail.description = decodeHtmlEntities(descMatch[1]);
+  if (!detail.description && descMatch)
+    detail.description = decodeHtmlEntities(descMatch[1]);
 
   const imageMatch = html.match(
     /<meta\s+property="og:image"\s+content="([^"]*)"/
   );
-  if (imageMatch) {
+  if (!detail.imageUrl && imageMatch) {
     detail.imageUrl = decodeHtmlEntities(imageMatch[1]);
     detail.images.push(detail.imageUrl);
   }
@@ -102,7 +264,7 @@ export function parseListingDetailFromPage(
     html.match(/"formatted_amount"\s*:\s*"([^"]+)"/) ??
     html.match(/"price"\s*:\s*"([^"]+)"/) ??
     html.match(/\"amount\"\s*:\s*"([^"]+)"/);
-  if (priceMatch) detail.price = priceMatch[1];
+  if (!detail.price && priceMatch) detail.price = priceMatch[1];
 
   // Extract additional images
   const imageRegex = /marketplace_listing_photos.*?"uri"\s*:\s*"([^"]+)"/g;
@@ -118,7 +280,7 @@ export function parseListingDetailFromPage(
   const sellerMatch = html.match(
     /"marketplace_listing_seller"\s*:\s*\{[^}]*"name"\s*:\s*"([^"]+)"/
   );
-  if (sellerMatch) {
+  if (!detail.sellerName && sellerMatch) {
     detail.sellerName = sellerMatch[1];
     detail.seller.name = sellerMatch[1];
   }
@@ -127,13 +289,13 @@ export function parseListingDetailFromPage(
   const conditionMatch = html.match(
     /"condition_text"\s*:\s*"([^"]+)"/
   ) ?? html.match(/"condition"\s*:\s*"([^"]+)"/);
-  if (conditionMatch) detail.condition = conditionMatch[1];
+  if (!detail.condition && conditionMatch) detail.condition = conditionMatch[1];
 
   // Extract location
   const locationMatch = html.match(
     /"location_text"\s*:\s*\{[^}]*"text"\s*:\s*"([^"]+)"/
   ) ?? html.match(/"reverse_geocode_city"\s*:\s*"([^"]+)"/);
-  if (locationMatch) detail.location = locationMatch[1];
+  if (!detail.location && locationMatch) detail.location = locationMatch[1];
 
   return detail;
 }

--- a/src/facebook/queries.ts
+++ b/src/facebook/queries.ts
@@ -1,9 +1,13 @@
 // Known GraphQL doc_ids for Facebook Marketplace.
 // These are hashed operation identifiers that Facebook rotates on deploys.
 // Run `npm run capture-queries` to discover current values if these break.
+//
+// Last verified: 2026-08-28 (captured from live www.facebook.com traffic)
+//   marketplace search   -> CometMarketplaceSearchContentPaginationQuery
+//   location typeahead   -> MarketplaceSearchAddressDataSourceQuery
 
-export const MARKETPLACE_SEARCH_DOC_ID = "7111939778879383";
-export const LOCATION_SEARCH_DOC_ID = "5585904654783609";
+export const MARKETPLACE_SEARCH_DOC_ID = "27212616558440397";
+export const LOCATION_SEARCH_DOC_ID = "9660140454040174";
 
 // Listing detail uses a different approach — we extract the doc_id dynamically
 // or fall back to fetching the listing page and parsing embedded data.
@@ -12,6 +16,11 @@ export let LISTING_DETAIL_DOC_ID = "";
 export function setListingDetailDocId(docId: string) {
   LISTING_DETAIL_DOC_ID = docId;
 }
+
+// Relay provider flag the web client sends with the search query. Facebook
+// rejects/ignores the query shape without it.
+const SPONSORED_DATA_FIELD_NAME_PROVIDER =
+  "__relay_internal__pv__GHLShouldChangeMarketplaceSponsoredDataFieldNamerelayprovider";
 
 export function buildSearchVariables(params: {
   query: string;
@@ -35,49 +44,59 @@ export function buildSearchVariables(params: {
         commerce_enable_local_pickup: true,
         commerce_enable_shipping: true,
         commerce_search_and_rp_available: true,
+        // Facebook sends an array here, not a scalar.
+        commerce_search_and_rp_category_id: params.category
+          ? [params.category]
+          : [],
         commerce_search_and_rp_condition: null,
         commerce_search_and_rp_ctime_days: null,
         filter_location_latitude: params.latitude,
         filter_location_longitude: params.longitude,
-        filter_price_lower_bound: params.minPrice
-          ? params.minPrice * 100
-          : 0,
+        filter_price_lower_bound: params.minPrice ? params.minPrice * 100 : 0,
         filter_price_upper_bound: params.maxPrice
           ? params.maxPrice * 100
           : 214748364700,
         filter_radius_km: params.radiusKm,
       },
       custom_request_params: {
+        browse_context: null,
+        contextual_filters: [],
+        referral_code: null,
+        referral_ui_component: null,
+        saved_search_strid: null,
+        search_vertical: "C2C",
+        seo_url: null,
+        serp_landing_settings: { virtual_category_id: "" },
         surface: "SEARCH",
+        virtual_contextual_filters: [],
       },
     },
+    scale: 2,
+    [SPONSORED_DATA_FIELD_NAME_PROVIDER]: true,
   };
 
+  // Only send a cursor when paginating — the search query treats an explicit
+  // null cursor as "past the end" and returns a NoResults feed story.
   if (params.cursor) {
     variables.cursor = params.cursor;
-  }
-
-  if (params.category) {
-    (
-      variables.params as Record<string, unknown>
-    ).browse_request_params = {
-      ...(
-        (variables.params as Record<string, unknown>)
-          .browse_request_params as Record<string, unknown>
-      ),
-      commerce_search_and_rp_category_id: params.category,
-    };
   }
 
   return variables;
 }
 
-export function buildLocationSearchVariables(query: string) {
+export function buildLocationSearchVariables(
+  query: string,
+  viewerCoordinates?: { latitude: number; longitude: number }
+) {
   return {
     params: {
       caller: "MARKETPLACE",
-      page_category: ["CITY", "SUBCITY", "NEIGHBORHOOD"],
+      country_filter: null,
+      integration_strategy: "STRING_MATCH",
+      page_category: ["CITY", "SUBCITY", "NEIGHBORHOOD", "POSTAL_CODE"],
       query,
+      search_type: "PLACE_TYPEAHEAD",
+      viewer_coordinates: viewerCoordinates ?? null,
     },
   };
 }


### PR DESCRIPTION
Searches and `get_listing` were both returning wrong or empty data. Two independent causes, split into one commit each so the durable half can be taken on its own.

### 1. `parseListingDetailFromPage` reads fields off the wrong listing

Each field was matched with a regex over the whole document, taking the first hit anywhere in the page. A Marketplace item page also embeds data for suggested and related listings, so title, price, location and seller were frequently read from a different listing than the one requested.

Facebook additionally splits one listing across several Relay fragments sharing the same `id` — one carries the title, another the price, another the seller — so matching a single node is not sufficient either.

This parses the embedded `application/json` blocks, collects every node whose `id` matches the requested listing, and merges them before reading fields. The existing regexes stay as fallbacks but no longer overwrite a value already resolved from the matched node.

`parseSearchResponse` now finds the listing connection by walking for an `edges` array whose nodes carry listings, instead of depending on the `marketplace_search.feed_units` path, which moves between deploys.

Two field mappings were also wrong, found while verifying against live responses:

- price is `formatted_amount_zeros_stripped` (`"$500"`), not `formatted_amount`
- on an item page, `location_text.text` is the displayed city; the `location` object holds the search-context lat/lng, not the item's

> This overlaps with #1, which adds further whole-page regexes for title, description and seller. Those still take the first match in the document, so they can still resolve to a neighbouring listing (the seller fallback there scans a fixed 2000-character window after the first `marketplace_listing_seller` hit). Matching on the listing id should cover the same cases more reliably. Happy to rebase on #1 instead if you'd prefer to land that first.

### 2. Both `doc_id` values were stale

Facebook returns HTTP 200 with an unparseable body for an unknown `doc_id`, so this surfaced as `No listings found` rather than an error, which makes it look like a location or auth problem. Auth was fine throughout — `initSession` throws when cookies, `c_user` or `fb_dtsg` are missing.

Recaptured from live traffic on 2026-08-28:

| operation | doc_id |
|---|---|
| `CometMarketplaceSearchContentPaginationQuery` | `27212616558440397` |
| `MarketplaceSearchAddressDataSourceQuery` | `9660140454040174` |

The variables had drifted too, and are now sent as the web client sends them: `scale` and the sponsored-data relay provider flag are required, `custom_request_params` needs its full object rather than just `surface`, and `commerce_search_and_rp_category_id` is an array. The location query gained `integration_strategy`, `search_type`, `country_filter` and optional `viewer_coordinates`.

`cursor` is now omitted entirely on the first page. Sending an explicit `null` cursor returns an `EntMarketplaceSearchFeedNoResults` story instead of results, which was the last thing keeping searches empty after the ID refresh.

These IDs rotate on every Facebook deploy and will go stale again, so this commit is the short-lived half. The README now notes that `capture-queries` needs Chrome fully quit (it launches Playwright against the real profile directory) and adds a DevTools console snippet to recapture the IDs without installing Playwright.

### Also

- documents `search_location`, which exists but was missing from the README
- notes that `delete_monitor` takes `name` while `check_monitors` takes `monitor_name`
- `FB_MCP_DEBUG=1` logs whether a listing node was matched, to tell a page-shape change apart from a genuinely empty result

### Verification

Built clean and exercised all seven tools over stdio against live Marketplace: `search_location` (7 results), `search_listings` (15 listings with correct titles, prices, cities and sellers), `get_listing` (title, `$500` matching the search feed, description, 7 photos, seller profile), and the full monitor lifecycle including dedup on a second `check_monitors`.
