### PR TITLE
Improve session authentication, MCP contracts, and Marketplace search reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ node_modules/
 dist/
 .env
 .env.local
+.local/
 *.db
 /tmp/
+.DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Build",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run build",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Server",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/dist/index.js",
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "npm: build",
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,35 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npm: build",
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": ["$tsc"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "npm: test",
+      "type": "npm",
+      "script": "test",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "npm: inspector",
+      "type": "npm",
+      "script": "inspector",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Or add to your Claude Code config manually:
       "command": "node",
       "args": ["/path/to/facebook-marketplace-mcp/dist/index.js"],
       "env": {
-        "CHROME_PROFILE": "Default",
         "FACEBOOK_SESSION_FILE": "/absolute/path/to/facebook-marketplace-mcp/.local/facebook-session.json"
       }
     }
@@ -54,7 +53,6 @@ command = "node"
 args = ["/path/to/facebook-marketplace-mcp/dist/index.js"]
 
 [mcp_servers.facebook-marketplace.env]
-"CHROME_PROFILE" = "Default"
 "FACEBOOK_SESSION_FILE" = "/absolute/path/to/facebook-marketplace-mcp/.local/facebook-session.json"
 
 ```
@@ -128,13 +126,12 @@ Delete a saved monitor.
 
 ## Configuration
 
-| Env Variable            | Default                        | Description                                          |
-| ----------------------- | ------------------------------ | ---------------------------------------------------- |
-| `CHROME_PROFILE`        | `Default`                      | Chrome profile directory name                        |
-| `FACEBOOK_SESSION_FILE` | `.local/facebook-session.json` | Cookie snapshot path; used before Chrome extraction  |
-| `MCP_ERROR_LOG_PATH`    | `.local/mcp-errors.jsonl`      | Alternate path for sanitized failed-tool diagnostics |
-| `MCP_CAPTURE_LISTING_HTML` | unset | Set to `1` to retain exact direct listing-page HTML locally |
-| `MCP_LISTING_CAPTURE_DIR` | `.local/listing-page-captures` | Alternate directory for opted-in raw HTML captures |
+| Env Variable               | Default                        | Description                                                 |
+| -------------------------- | ------------------------------ | ----------------------------------------------------------- |
+| `FACEBOOK_SESSION_FILE`    | `.local/facebook-session.json` | Login session snapshot path                                 |
+| `MCP_ERROR_LOG_PATH`       | `.local/mcp-errors.jsonl`      | Alternate path for sanitized failed-tool diagnostics        |
+| `MCP_CAPTURE_LISTING_HTML` | unset                          | Set to `1` to retain exact direct listing-page HTML locally |
+| `MCP_LISTING_CAPTURE_DIR`  | `.local/listing-page-captures` | Alternate directory for opted-in raw HTML captures          |
 
 ### Failed-request diagnostics
 
@@ -165,13 +162,10 @@ is reported only on stderr and does not alter the request result.
 
 ### Cookie file authentication
 
-On first start, the server extracts active Facebook cookies from Chrome and
-saves them to `.local/facebook-session.json`. Later starts use that snapshot
-and do not access Chrome or Keychain. Set `FACEBOOK_SESSION_FILE` to store the
-same private JSON snapshot elsewhere. The file may be either a JSON array or
-an object containing a `cookies` array. `c_user` and `xs` are required; `datr`,
-`fr`, and `sb` are recommended when present. Chrome-style fields such as
-`domain`, `path`, `expirationDate`, `secure`, and `httpOnly` are accepted.
+Run `npm run login` before starting the server. It saves Facebook cookies and
+Chrome's user agent to `.local/facebook-session.json`. Set `FACEBOOK_SESSION_FILE`
+to use another path. The server requires this login-generated session format,
+including its browser user agent; cookie-only exports are not supported.
 
 ### Interactive login
 
@@ -184,40 +178,15 @@ npm run login
 This opens a visible, dedicated Chrome profile at
 `.local/facebook-login-profile`. Complete Facebook login (including any
 checkpoint), return to Marketplace, and press Enter in the terminal. The
-command validates the Marketplace page and saves only normalized cookies to
+command validates the Marketplace page and saves normalized cookies and the browser user agent to
 `FACEBOOK_SESSION_FILE` or `.local/facebook-session.json`; page tokens are not
 stored. It closes Chrome when it succeeds or fails, while retaining the private
 login profile for the next interactive refresh.
 
-```json
-{
-  "cookies": [
-    {
-      "name": "c_user",
-      "value": "YOUR_USER_ID",
-      "domain": ".facebook.com",
-      "path": "/",
-      "secure": true,
-      "httpOnly": true
-    },
-    {
-      "name": "xs",
-      "value": "YOUR_SESSION_VALUE",
-      "domain": ".facebook.com",
-      "path": "/",
-      "secure": true,
-      "httpOnly": true
-    }
-  ]
-}
-```
-
 The server writes snapshots atomically with owner-only directory and file
 permissions, and refuses to overwrite symbolic links. Keep the file out of
-version control. If it is missing, malformed, or expired, the server falls back
-to `CHROME_PROFILE` and replaces it with a fresh snapshot. Restart the MCP
-server after replacing the file manually; cookies and page tokens are kept in
-memory for the running process.
+version control. If it is missing, malformed, or expired, run `npm run login` again. Restart the
+MCP server afterward to load the new cookies and browser user agent.
 
 ## Updating GraphQL Queries
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ args = ["/path/to/facebook-marketplace-mcp/dist/index.js"]
 
 ## Tools
 
-### `search_listings`
+### `facebook_marketplace_search_listings`
 
 Search Marketplace by query, location, and filters.
 
@@ -76,7 +76,7 @@ Search Marketplace by query, location, and filters.
 | `category`  | string | no       | Category ID                 |
 | `limit`     | number | no       | Max results (default: 20)   |
 
-### `get_listing`
+### `facebook_marketplace_get_listing`
 
 Get full details for a specific listing.
 
@@ -84,7 +84,7 @@ Get full details for a specific listing.
 | ------------ | ------ | -------- | ---------------------- |
 | `listing_id` | string | yes      | Marketplace listing ID |
 
-### `search_location`
+### `facebook_marketplace_search_location`
 
 Look up a city, neighborhood, or ZIP code to get coordinates for
 `search_listings`.
@@ -93,7 +93,7 @@ Look up a city, neighborhood, or ZIP code to get coordinates for
 | --------- | ------ | -------- | --------------------------------------------- |
 | `query`   | string | yes      | Location text, such as `Boston MA` or `02108` |
 
-### `monitor_search`
+### `facebook_marketplace_monitor_search`
 
 Save a search as a monitor to track new listings over time.
 
@@ -107,7 +107,7 @@ Save a search as a monitor to track new listings over time.
 | `min_price` | number | no       | Min price            |
 | `max_price` | number | no       | Max price            |
 
-### `check_monitors`
+### `facebook_marketplace_check_monitors`
 
 Check monitors for new listings since last check.
 
@@ -115,28 +115,60 @@ Check monitors for new listings since last check.
 | -------------- | ------ | -------- | --------------------------------------- |
 | `monitor_name` | string | no       | Check specific monitor, or omit for all |
 
-### `list_monitors`
+### `facebook_marketplace_list_monitors`
 
 List all saved monitors.
 
-### `delete_monitor`
+### `facebook_marketplace_delete_monitor`
 
 Delete a saved monitor.
 
 ## Configuration
 
-| Env Variable            | Default   | Description                                                        |
-| ----------------------- | --------- | ------------------------------------------------------------------ |
-| `CHROME_PROFILE`        | `Default` | Chrome profile directory name                                      |
-| `FACEBOOK_SESSION_FILE` | unset     | Absolute path to a JSON cookie file; used before Chrome extraction |
+| Env Variable            | Default                   | Description                                                        |
+| ----------------------- | ------------------------- | ------------------------------------------------------------------ |
+| `CHROME_PROFILE`        | `Default`                 | Chrome profile directory name                                      |
+| `FACEBOOK_SESSION_FILE` | `.local/facebook-session.json` | Cookie snapshot path; used before Chrome extraction |
+| `MCP_ERROR_LOG_PATH`    | `.local/mcp-errors.jsonl` | Alternate path for sanitized failed-tool diagnostics               |
+
+### Failed-request diagnostics
+
+Every failed MCP tool call is appended as a JSON line to
+`.local/mcp-errors.jsonl`. The error returned by the tool includes a
+`diagnostic ID`; search the file for that ID to inspect the matching record.
+Set `MCP_ERROR_LOG_PATH` when the log should live elsewhere.
+
+Records include the timestamp, tool, bounded input summary, error type/message,
+and safe Facebook request metadata such as the operation, path, status, and
+GraphQL document ID. They never include cookies, authorization or CSRF values,
+page tokens, request bodies, raw headers, HTML, or response bodies. The server
+continues returning the original MCP tool error if diagnostic writing fails.
 
 ### Cookie file authentication
 
-If Keychain access is unavailable, create a local JSON file with cookies copied
-from Chrome's Facebook cookie storage. The file may be either a JSON array or
+On first start, the server extracts active Facebook cookies from Chrome and
+saves them to `.local/facebook-session.json`. Later starts use that snapshot
+and do not access Chrome or Keychain. Set `FACEBOOK_SESSION_FILE` to store the
+same private JSON snapshot elsewhere. The file may be either a JSON array or
 an object containing a `cookies` array. `c_user` and `xs` are required; `datr`,
 `fr`, and `sb` are recommended when present. Chrome-style fields such as
 `domain`, `path`, `expirationDate`, `secure`, and `httpOnly` are accepted.
+
+### Interactive login
+
+When the session must be refreshed, run:
+
+```bash
+npm run login
+```
+
+This opens a visible, dedicated Chrome profile at
+`.local/facebook-login-profile`. Complete Facebook login (including any
+checkpoint), return to Marketplace, and press Enter in the terminal. The
+command validates the Marketplace page and saves only normalized cookies to
+`FACEBOOK_SESSION_FILE` or `.local/facebook-session.json`; page tokens are not
+stored. It closes Chrome when it succeeds or fails, while retaining the private
+login profile for the next interactive refresh.
 
 ```json
 {
@@ -161,12 +193,12 @@ an object containing a `cookies` array. `c_user` and `xs` are required; `datr`,
 }
 ```
 
-Keep this file out of version control and restrict it to your account, for
-example `chmod 600 .local/facebook-session.json`. When the file is valid, the
-server does not access Chrome or Keychain. If the file cannot be read or does
-not contain an active Facebook session, it falls back to `CHROME_PROFILE`.
-Restart the MCP server after replacing the file; cookies and page tokens are
-kept in memory for the running process.
+The server writes snapshots atomically with owner-only directory and file
+permissions, and refuses to overwrite symbolic links. Keep the file out of
+version control. If it is missing, malformed, or expired, the server falls back
+to `CHROME_PROFILE` and replaces it with a fresh snapshot. Restart the MCP
+server after replacing the file manually; cookies and page tokens are kept in
+memory for the running process.
 
 ## Updating GraphQL Queries
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Facebook's web client makes all Marketplace requests as `POST /api/graphql/` wit
 ## Prerequisites
 
 - **macOS** (cookie extraction uses Keychain)
-- **Google Chrome** with an active Facebook login
-- **Node.js** 20+
+- **Google Chrome** with an active Facebook login or a Facebook cookie JSON file configured with `FACEBOOK_SESSION_FILE`
+- **Node.js** 22+
 
 ## Installation
 
@@ -38,67 +38,135 @@ Or add to your Claude Code config manually:
       "command": "node",
       "args": ["/path/to/facebook-marketplace-mcp/dist/index.js"],
       "env": {
-        "CHROME_PROFILE": "Default"
+        "CHROME_PROFILE": "Default",
+        "FACEBOOK_SESSION_FILE": "/absolute/path/to/facebook-marketplace-mcp/.local/facebook-session.json"
       }
     }
   }
 }
 ```
 
+## Setup with Codex
+
+```toml
+[mcp_servers.facebook-marketplace]
+command = "node"
+args = ["/path/to/facebook-marketplace-mcp/dist/index.js"]
+
+[mcp_servers.facebook-marketplace.env]
+"CHROME_PROFILE" = "Default"
+"FACEBOOK_SESSION_FILE" = "/absolute/path/to/facebook-marketplace-mcp/.local/facebook-session.json"
+
+```
+
 ## Tools
 
 ### `search_listings`
+
 Search Marketplace by query, location, and filters.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `query` | string | yes | Search term |
-| `latitude` | number | yes | Latitude of search center |
-| `longitude` | number | yes | Longitude of search center |
-| `radius_km` | number | no | Search radius (default: 50) |
-| `min_price` | number | no | Min price in dollars |
-| `max_price` | number | no | Max price in dollars |
-| `category` | string | no | Category ID |
-| `limit` | number | no | Max results (default: 20) |
+| Parameter   | Type   | Required | Description                 |
+| ----------- | ------ | -------- | --------------------------- |
+| `query`     | string | yes      | Search term                 |
+| `latitude`  | number | yes      | Latitude of search center   |
+| `longitude` | number | yes      | Longitude of search center  |
+| `radius_km` | number | no       | Search radius (default: 50) |
+| `min_price` | number | no       | Min price in dollars        |
+| `max_price` | number | no       | Max price in dollars        |
+| `category`  | string | no       | Category ID                 |
+| `limit`     | number | no       | Max results (default: 20)   |
 
 ### `get_listing`
+
 Get full details for a specific listing.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `listing_id` | string | yes | Marketplace listing ID |
+| Parameter    | Type   | Required | Description            |
+| ------------ | ------ | -------- | ---------------------- |
+| `listing_id` | string | yes      | Marketplace listing ID |
+
+### `search_location`
+
+Look up a city, neighborhood, or ZIP code to get coordinates for
+`search_listings`.
+
+| Parameter | Type   | Required | Description                                   |
+| --------- | ------ | -------- | --------------------------------------------- |
+| `query`   | string | yes      | Location text, such as `Boston MA` or `02108` |
 
 ### `monitor_search`
+
 Save a search as a monitor to track new listings over time.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `name` | string | yes | Monitor name |
-| `query` | string | yes | Search term |
-| `latitude` | number | yes | Search center lat |
-| `longitude` | number | yes | Search center lng |
-| `radius_km` | number | no | Radius (default: 50) |
-| `min_price` | number | no | Min price |
-| `max_price` | number | no | Max price |
+| Parameter   | Type   | Required | Description          |
+| ----------- | ------ | -------- | -------------------- |
+| `name`      | string | yes      | Monitor name         |
+| `query`     | string | yes      | Search term          |
+| `latitude`  | number | yes      | Search center lat    |
+| `longitude` | number | yes      | Search center lng    |
+| `radius_km` | number | no       | Radius (default: 50) |
+| `min_price` | number | no       | Min price            |
+| `max_price` | number | no       | Max price            |
 
 ### `check_monitors`
+
 Check monitors for new listings since last check.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `monitor_name` | string | no | Check specific monitor, or omit for all |
+| Parameter      | Type   | Required | Description                             |
+| -------------- | ------ | -------- | --------------------------------------- |
+| `monitor_name` | string | no       | Check specific monitor, or omit for all |
 
 ### `list_monitors`
+
 List all saved monitors.
 
 ### `delete_monitor`
+
 Delete a saved monitor.
 
 ## Configuration
 
-| Env Variable | Default | Description |
-|-------------|---------|-------------|
-| `CHROME_PROFILE` | `Default` | Chrome profile directory name |
+| Env Variable            | Default   | Description                                                        |
+| ----------------------- | --------- | ------------------------------------------------------------------ |
+| `CHROME_PROFILE`        | `Default` | Chrome profile directory name                                      |
+| `FACEBOOK_SESSION_FILE` | unset     | Absolute path to a JSON cookie file; used before Chrome extraction |
+
+### Cookie file authentication
+
+If Keychain access is unavailable, create a local JSON file with cookies copied
+from Chrome's Facebook cookie storage. The file may be either a JSON array or
+an object containing a `cookies` array. `c_user` and `xs` are required; `datr`,
+`fr`, and `sb` are recommended when present. Chrome-style fields such as
+`domain`, `path`, `expirationDate`, `secure`, and `httpOnly` are accepted.
+
+```json
+{
+  "cookies": [
+    {
+      "name": "c_user",
+      "value": "YOUR_USER_ID",
+      "domain": ".facebook.com",
+      "path": "/",
+      "secure": true,
+      "httpOnly": true
+    },
+    {
+      "name": "xs",
+      "value": "YOUR_SESSION_VALUE",
+      "domain": ".facebook.com",
+      "path": "/",
+      "secure": true,
+      "httpOnly": true
+    }
+  ]
+}
+```
+
+Keep this file out of version control and restrict it to your account, for
+example `chmod 600 .local/facebook-session.json`. When the file is valid, the
+server does not access Chrome or Keychain. If the file cannot be read or does
+not contain an active Facebook session, it falls back to `CHROME_PROFILE`.
+Restart the MCP server after replacing the file; cookies and page tokens are
+kept in memory for the running process.
 
 ## Updating GraphQL Queries
 
@@ -111,6 +179,22 @@ npm run capture-queries
 ```
 
 This opens a browser, navigates Marketplace, and captures current query IDs. Update `src/facebook/queries.ts` with the new values.
+
+## Verification
+
+```bash
+npm test
+npm run build
+```
+
+### MCP Inspector
+
+Use the Inspector's browser interface to explore and invoke the local stdio
+server:
+
+```bash
+npm run inspector
+```
 
 ## Rate Limiting
 

--- a/README.md
+++ b/README.md
@@ -65,16 +65,19 @@ args = ["/path/to/facebook-marketplace-mcp/dist/index.js"]
 
 Search Marketplace by query, location, and filters.
 
-| Parameter   | Type   | Required | Description                 |
-| ----------- | ------ | -------- | --------------------------- |
-| `query`     | string | yes      | Search term                 |
-| `latitude`  | number | yes      | Latitude of search center   |
-| `longitude` | number | yes      | Longitude of search center  |
-| `radius_km` | number | no       | Search radius (default: 50) |
-| `min_price` | number | no       | Min price in dollars        |
-| `max_price` | number | no       | Max price in dollars        |
-| `category`  | string | no       | Category ID                 |
-| `limit`     | number | no       | Max results (default: 20)   |
+| Parameter         | Type   | Required | Description                                                                                   |
+| ----------------- | ------ | -------- | --------------------------------------------------------------------------------------------- |
+| `query`           | string | yes      | Search term                                                                                   |
+| `latitude`        | number | yes      | Latitude of search center                                                                     |
+| `longitude`       | number | yes      | Longitude of search center                                                                    |
+| `radius_km`       | number | no       | Search radius (default: 50)                                                                   |
+| `min_price`       | number | no       | Min price in dollars                                                                          |
+| `max_price`       | number | no       | Max price in dollars                                                                          |
+| `category`        | string | no       | Category ID                                                                                   |
+| `sort_by`         | string | no       | `suggested` (default), `distance`, `date_listed`, `price_low_to_high`, or `price_high_to_low` |
+| `delivery_method` | string | no       | `all` (default), `local_pickup`, or `shipping`                                                |
+| `date_listed`     | string | no       | `all` (default), `last_24_hours`, `last_7_days`, or `last_30_days`                            |
+| `limit`           | number | no       | Max results (default: 20)                                                                     |
 
 ### `facebook_marketplace_get_listing`
 
@@ -125,11 +128,13 @@ Delete a saved monitor.
 
 ## Configuration
 
-| Env Variable            | Default                   | Description                                                        |
-| ----------------------- | ------------------------- | ------------------------------------------------------------------ |
-| `CHROME_PROFILE`        | `Default`                 | Chrome profile directory name                                      |
-| `FACEBOOK_SESSION_FILE` | `.local/facebook-session.json` | Cookie snapshot path; used before Chrome extraction |
-| `MCP_ERROR_LOG_PATH`    | `.local/mcp-errors.jsonl` | Alternate path for sanitized failed-tool diagnostics               |
+| Env Variable            | Default                        | Description                                          |
+| ----------------------- | ------------------------------ | ---------------------------------------------------- |
+| `CHROME_PROFILE`        | `Default`                      | Chrome profile directory name                        |
+| `FACEBOOK_SESSION_FILE` | `.local/facebook-session.json` | Cookie snapshot path; used before Chrome extraction  |
+| `MCP_ERROR_LOG_PATH`    | `.local/mcp-errors.jsonl`      | Alternate path for sanitized failed-tool diagnostics |
+| `MCP_CAPTURE_LISTING_HTML` | unset | Set to `1` to retain exact direct listing-page HTML locally |
+| `MCP_LISTING_CAPTURE_DIR` | `.local/listing-page-captures` | Alternate directory for opted-in raw HTML captures |
 
 ### Failed-request diagnostics
 
@@ -143,6 +148,20 @@ and safe Facebook request metadata such as the operation, path, status, and
 GraphQL document ID. They never include cookies, authorization or CSRF values,
 page tokens, request bodies, raw headers, HTML, or response bodies. The server
 continues returning the original MCP tool error if diagnostic writing fails.
+
+### Opt-in raw listing-page captures
+
+Set `MCP_CAPTURE_LISTING_HTML=1` to save the exact HTML response from every
+direct listing-page request, including successful, login, block, and error
+pages. Captures are written before response status handling and parsing, so
+they can be compared later when Facebook markup changes.
+
+Raw captures are separate from `mcp-errors.jsonl`, never appear in MCP output,
+and are stored as `0600` files in a `0700` directory. They can contain private
+Facebook page data, are not pruned automatically, and must not be committed or
+shared. Set `MCP_LISTING_CAPTURE_DIR` to use another protected local directory;
+remove captures manually when they are no longer needed. A capture-write failure
+is reported only on stderr and does not alter the request result.
 
 ### Cookie file authentication
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@modelcontextprotocol/inspector": "^2.5.0",
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.0.0",
+        "playwright": "^1.62.1",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"
       },
@@ -3095,6 +3096,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,35 @@
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "better-sqlite3": "^11.0.0",
+        "better-sqlite3": "^13.0.3",
         "zod": "^3.25.0"
       },
       "bin": {
         "facebook-marketplace-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@modelcontextprotocol/inspector": "^2.5.0",
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.0.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.5.tgz",
+      "integrity": "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -465,15 +483,146 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.5.tgz",
+      "integrity": "sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector/-/inspector-2.5.0.tgz",
+      "integrity": "sha512-E7YQiWyuXLVPPbDRO5HpyCXcYnwG8EPHNbqNPn5u+AxDzfNi+6Idw2vRYW9CQplJpkxGkNtquTFXGZ0ZncksIg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^2.0.12",
+        "@modelcontextprotocol/client": "2.0.0",
+        "@modelcontextprotocol/core": "2.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.4",
+        "@modelcontextprotocol/server": "2.0.0",
+        "@modelcontextprotocol/server-legacy": "2.0.0",
+        "@napi-rs/keyring": "^1.3.0",
+        "@vitejs/plugin-react": "^6.0.0",
+        "ajv": "^8.17.1",
+        "atomically": "^2.1.1",
+        "chokidar": "^4.0.3",
+        "commander": "^13.1.0",
+        "hono": "^4.13.1",
+        "ink": "^6.0.0",
+        "open": "^10.2.0",
+        "pino": "^9.14.0",
+        "proper-lockfile": "^4.1.2",
+        "react": "^19.0.0",
+        "undici": "^8.5.0",
+        "vite": "^8.1.5",
+        "yaml": "^2.9.0",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "mcp-inspector": "clients/launcher/build/index.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -516,6 +665,631 @@
         }
       }
     },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-legacy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-legacy/-/server-legacy-2.0.0.tgz",
+      "integrity": "sha512-LnffC1BSqFMHtMQxEz92lqDpHWma+ErV3ghdHDgdkCyYzVcCYKcUT5loq4kflty+Bf9C9qjJqbnphyBWyCqo8Q==",
+      "deprecated": "This package is a frozen copy of v1's SSE transport and OAuth Authorization Server helpers for migration purposes only. Use StreamableHTTP from @modelcontextprotocol/server and a dedicated OAuth server in production. Will not receive new features.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "express-rate-limit": "^8.2.1",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-legacy/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
+      "integrity": "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.3.0",
+        "@napi-rs/keyring-darwin-x64": "1.3.0",
+        "@napi-rs/keyring-freebsd-x64": "1.3.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.3.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.3.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.3.0.tgz",
+      "integrity": "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -534,6 +1308,36 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.1.tgz",
+      "integrity": "sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "oxc-transform-react": "^0.145.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "oxc-transform-react": {
+          "optional": true
+        }
       }
     },
     "node_modules/accepts": {
@@ -582,72 +1386,109 @@
         }
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
-      "hasInstallScript": true,
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "license": "MIT",
       "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+        "node-addon-api": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -657,28 +1498,33 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bytes": {
@@ -719,11 +1565,103 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -745,6 +1683,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/cookie": {
@@ -813,28 +1761,47 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+    "node_modules/default-browser": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mimic-response": "^3.1.0"
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/depd": {
@@ -850,6 +1817,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -875,6 +1843,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -884,13 +1859,17 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -912,9 +1891,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -922,6 +1901,19 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types",
+        "tests/browser-compat"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -971,6 +1963,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -999,15 +2001,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -1054,12 +2047,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1078,9 +2072,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -1093,11 +2087,23 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -1138,12 +2144,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1166,6 +2166,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1218,12 +2231,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1235,6 +2242,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -1249,9 +2263,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1261,9 +2275,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1305,25 +2319,18 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -1331,16 +2338,60 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
+    "node_modules/ink": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-6.8.0.tgz",
+      "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.2.4",
+        "ansi-escapes": "^7.3.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^5.1.1",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.39.10",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.33.0",
+        "scheduler": "^0.27.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^8.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^8.1.1",
+        "terminal-size": "^4.0.1",
+        "type-fest": "^5.4.1",
+        "widest-line": "^6.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.0.0",
+        "react": ">=19.0.0",
+        "react-devtools-core": ">=6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1355,11 +2406,94 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
+      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1387,6 +2521,279 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1443,32 +2850,15 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1476,11 +2866,24 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -1491,16 +2894,13 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+    "node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
       "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/object-assign": {
@@ -1524,6 +2924,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -1545,6 +2955,41 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1552,6 +2997,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/path-key": {
@@ -1573,6 +3028,66 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -1582,31 +3097,62 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "node_modules/proxy-addr": {
@@ -1622,23 +3168,14 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1646,6 +3183,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -1671,33 +3215,54 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "scheduler": "^0.27.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/require-from-string": {
@@ -1719,6 +3284,67 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1735,25 +3361,28 @@
         "node": ">= 18"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1761,17 +3390,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1846,14 +3470,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1917,49 +3541,71 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
     },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/statuses": {
@@ -1971,50 +3617,107 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/toidentifier": {
@@ -2046,30 +3749,51 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
+    "node_modules/type-fest": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.9.0.tgz",
+      "integrity": "sha512-yANm3Jr3GiJ1qgJlxGAVxTOIcEOk1rhQHamlXtnrCK7EHP4HeM9OGxtMg/W7HFdrVzw/ZWJKGVIJusVH85sLtw==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "dependencies": {
-        "safe-buffer": "^5.0.1"
+        "tagged-tag": "^1.0.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -2084,6 +3808,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -2102,12 +3836,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2116,6 +3844,91 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2132,11 +3945,124 @@
         "node": ">= 8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
+      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "inspector": "npm run build && mcp-inspector node dist/index.js",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
+    "login": "tsx src/facebook/login.ts",
     "capture-queries": "tsx scripts/capture-queries.ts"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
     "@modelcontextprotocol/inspector": "^2.5.0",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.0.0",
+    "playwright": "^1.62.1",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,19 +9,25 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "tsx --test test/*.test.ts",
+    "inspector": "npm run build && mcp-inspector node dist/index.js",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "capture-queries": "tsx scripts/capture-queries.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "^13.0.3",
     "zod": "^3.25.0"
   },
   "devDependencies": {
+    "@modelcontextprotocol/inspector": "^2.5.0",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   }
 }

--- a/scripts/capture-queries.ts
+++ b/scripts/capture-queries.ts
@@ -28,7 +28,7 @@ import fs from "node:fs";
 
 const CHROME_USER_DATA = path.join(
   os.homedir(),
-  "Library/Application Support/Google/Chrome"
+  "Library/Application Support/Google/Chrome",
 );
 
 interface CapturedQuery {
@@ -100,7 +100,7 @@ async function main() {
   // Try to search
   try {
     const searchInput = page.locator(
-      'input[placeholder*="Search"], input[aria-label*="Search"]'
+      'input[placeholder*="Search"], input[aria-label*="Search"]',
     );
     if (await searchInput.isVisible({ timeout: 5000 })) {
       await searchInput.fill("laptop");
@@ -139,15 +139,12 @@ async function main() {
   const outputPath = path.join(
     import.meta.dirname ?? ".",
     "..",
-    "captured-queries.json"
+    "captured-queries.json",
   );
-  fs.writeFileSync(
-    outputPath,
-    JSON.stringify([...unique.values()], null, 2)
-  );
+  fs.writeFileSync(outputPath, JSON.stringify([...unique.values()], null, 2));
   console.log(`\nSaved to ${outputPath}`);
   console.log(
-    "\nUpdate src/facebook/queries.ts with the new doc_id values if they changed."
+    "\nUpdate src/facebook/queries.ts with the new doc_id values if they changed.",
   );
 }
 

--- a/src/facebook/auth.ts
+++ b/src/facebook/auth.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import Database from "better-sqlite3";
@@ -10,18 +11,71 @@ const CHROME_ITERATIONS = 1003;
 const CHROME_KEY_LENGTH = 16;
 const CHROME_IV = Buffer.alloc(16, " ");
 
+type CookieExtractor = (domain: string, profile?: string) => FacebookCookie[];
+
+interface CookieFileEntry {
+  name?: unknown;
+  value?: unknown;
+  host?: unknown;
+  domain?: unknown;
+  path?: unknown;
+  expires?: unknown;
+  expirationDate?: unknown;
+  secure?: unknown;
+  httpOnly?: unknown;
+  is_secure?: unknown;
+  is_httponly?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isFacebookDomain(host: string): boolean {
+  const normalized = host.toLowerCase().replace(/^\./, "");
+  return normalized === "facebook.com" || normalized.endsWith(".facebook.com");
+}
+
+function toBoolean(value: unknown): boolean {
+  return value === true || value === 1;
+}
+
+function getExpiry(entry: CookieFileEntry): number {
+  const raw = entry.expirationDate ?? entry.expires;
+  if (raw === undefined || raw === null || raw === "") return 0;
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) {
+    throw new Error("cookie expiry must be a non-negative number");
+  }
+  return raw;
+}
+
+function requireSessionCookies(cookies: FacebookCookie[]): FacebookCookie[] {
+  const nowInSeconds = Date.now() / 1000;
+  const activeCookies = cookies.filter(
+    (cookie) => cookie.expires === 0 || cookie.expires > nowInSeconds,
+  );
+
+  for (const name of ["c_user", "xs"]) {
+    if (!getCookieValue(activeCookies, name)) {
+      throw new Error(`session file has no active ${name} cookie`);
+    }
+  }
+
+  return activeCookies;
+}
+
 function getChromePassword(): string {
   try {
     return execSync(
       'security find-generic-password -w -s "Chrome Safe Storage" -a "Chrome"',
-      { stdio: ["pipe", "pipe", "pipe"] }
+      { stdio: ["pipe", "pipe", "pipe"] },
     )
       .toString()
       .trim();
   } catch {
     throw new Error(
       "Failed to get Chrome password from Keychain. " +
-        "Make sure Chrome is installed and you approve the Keychain prompt."
+        "Make sure Chrome is installed and you approve the Keychain prompt.",
     );
   }
 }
@@ -32,7 +86,7 @@ function deriveChromeKey(password: string): Buffer {
     CHROME_SALT,
     CHROME_ITERATIONS,
     CHROME_KEY_LENGTH,
-    "sha1"
+    "sha1",
   );
 }
 
@@ -72,13 +126,13 @@ function getCookieDbPath(profile = "Default"): string {
     os.homedir(),
     "Library/Application Support/Google/Chrome",
     profile,
-    "Cookies"
+    "Cookies",
   );
 }
 
 export function extractChromeCookies(
   domain: string,
-  profile = "Default"
+  profile = "Default",
 ): FacebookCookie[] {
   const cookiePath = getCookieDbPath(profile);
 
@@ -91,7 +145,7 @@ export function extractChromeCookies(
   } catch {
     throw new Error(
       `Failed to copy Chrome cookie DB from ${cookiePath}. ` +
-        "Make sure Chrome is installed and the profile exists."
+        "Make sure Chrome is installed and the profile exists.",
     );
   }
 
@@ -111,7 +165,7 @@ export function extractChromeCookies(
         `SELECT host_key, name, value, encrypted_value, path, expires_utc,
                 is_secure, is_httponly
          FROM cookies
-         WHERE host_key LIKE ?`
+         WHERE host_key LIKE ?`,
       )
       .all(`%${domain}`) as Array<{
       host_key: string;
@@ -126,11 +180,7 @@ export function extractChromeCookies(
 
     return rows.map((row) => {
       let value = row.value;
-      if (
-        !value &&
-        row.encrypted_value &&
-        row.encrypted_value.length > 0
-      ) {
+      if (!value && row.encrypted_value && row.encrypted_value.length > 0) {
         value = decryptCookieValue(row.encrypted_value, key);
       }
       return {
@@ -153,6 +203,100 @@ export function extractChromeCookies(
   }
 }
 
+/**
+ * Loads cookies from a user-managed JSON file. The file may be a cookie array
+ * or an object with a `cookies` array, matching common Chrome-export layouts.
+ */
+export function loadFacebookCookiesFromFile(
+  filePath: string,
+): FacebookCookie[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, "utf8"));
+  } catch {
+    throw new Error("could not read valid JSON from FACEBOOK_SESSION_FILE");
+  }
+
+  const entries = Array.isArray(parsed)
+    ? parsed
+    : isRecord(parsed) && Array.isArray(parsed.cookies)
+      ? parsed.cookies
+      : null;
+
+  if (!entries) {
+    throw new Error(
+      "session file must be a cookie array or an object with a cookies array",
+    );
+  }
+
+  const cookies = entries.map((entry, index): FacebookCookie => {
+    if (!isRecord(entry)) {
+      throw new Error(`cookie ${index + 1} must be an object`);
+    }
+
+    const cookie = entry as CookieFileEntry;
+    if (typeof cookie.name !== "string" || !cookie.name) {
+      throw new Error(`cookie ${index + 1} must have a name`);
+    }
+    if (typeof cookie.value !== "string" || !cookie.value) {
+      throw new Error(`cookie ${index + 1} must have a value`);
+    }
+
+    const host =
+      typeof cookie.domain === "string"
+        ? cookie.domain
+        : typeof cookie.host === "string"
+          ? cookie.host
+          : ".facebook.com";
+    if (!isFacebookDomain(host)) {
+      throw new Error(`cookie ${index + 1} is not scoped to facebook.com`);
+    }
+
+    return {
+      host,
+      name: cookie.name,
+      value: cookie.value,
+      path: typeof cookie.path === "string" ? cookie.path : "/",
+      expires: getExpiry(cookie),
+      secure: toBoolean(cookie.secure ?? cookie.is_secure),
+      httpOnly: toBoolean(cookie.httpOnly ?? cookie.is_httponly),
+    };
+  });
+
+  return requireSessionCookies(cookies);
+}
+
+export function loadFacebookCookies(options: {
+  sessionFile?: string;
+  chromeProfile?: string;
+  extractChrome?: CookieExtractor;
+}): FacebookCookie[] {
+  const extractChrome = options.extractChrome ?? extractChromeCookies;
+
+  console.log(options.chromeProfile, "chromeProfile");
+  if (!options.sessionFile) {
+    return extractChrome("facebook.com", options.chromeProfile);
+  }
+
+  try {
+    return loadFacebookCookiesFromFile(options.sessionFile);
+  } catch (fileError) {
+    try {
+      return extractChrome("facebook.com", options.chromeProfile);
+    } catch (chromeError) {
+      const fileMessage =
+        fileError instanceof Error ? fileError.message : "unknown file error";
+      const chromeMessage =
+        chromeError instanceof Error
+          ? chromeError.message
+          : "unknown Chrome error";
+      throw new Error(
+        `Could not load Facebook cookies from FACEBOOK_SESSION_FILE (${fileMessage}) or Chrome (${chromeMessage}).`,
+      );
+    }
+  }
+}
+
 export function cookiesToHeader(cookies: FacebookCookie[]): string {
   return cookies
     .map((c) => {
@@ -165,7 +309,7 @@ export function cookiesToHeader(cookies: FacebookCookie[]): string {
 
 export function getCookieValue(
   cookies: FacebookCookie[],
-  name: string
+  name: string,
 ): string | undefined {
   return cookies.find((c) => c.name === name)?.value;
 }

--- a/src/facebook/auth.ts
+++ b/src/facebook/auth.ts
@@ -1,6 +1,16 @@
 import crypto from "node:crypto";
 import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import Database from "better-sqlite3";
@@ -10,6 +20,12 @@ const CHROME_SALT = "saltysalt";
 const CHROME_ITERATIONS = 1003;
 const CHROME_KEY_LENGTH = 16;
 const CHROME_IV = Buffer.alloc(16, " ");
+const CHROME_EPOCH_OFFSET_SECONDS = 11_644_473_600;
+
+export const DEFAULT_FACEBOOK_SESSION_FILE = path.resolve(
+  process.cwd(),
+  ".local/facebook-session.json",
+);
 
 type CookieExtractor = (domain: string, profile?: string) => FacebookCookie[];
 
@@ -62,6 +78,14 @@ function requireSessionCookies(cookies: FacebookCookie[]): FacebookCookie[] {
   }
 
   return activeCookies;
+}
+
+function chromeExpiryToUnixSeconds(expiresUtc: number): number {
+  if (!expiresUtc) return 0;
+  return Math.max(
+    0,
+    Math.floor(expiresUtc / 1_000_000 - CHROME_EPOCH_OFFSET_SECONDS),
+  );
 }
 
 function getChromePassword(): string {
@@ -188,7 +212,7 @@ export function extractChromeCookies(
         name: row.name,
         value,
         path: row.path,
-        expires: row.expires_utc,
+        expires: chromeExpiryToUnixSeconds(row.expires_utc),
         secure: !!row.is_secure,
         httpOnly: !!row.is_httponly,
       };
@@ -200,6 +224,66 @@ export function extractChromeCookies(
     } catch {
       // cleanup failure is non-fatal
     }
+  }
+}
+
+/**
+ * Persists normalized Facebook cookies in the same JSON envelope accepted by
+ * loadFacebookCookiesFromFile. The snapshot is private to the current user.
+ */
+export function saveFacebookCookiesToFile(
+  filePath: string,
+  cookies: FacebookCookie[],
+): void {
+  const activeCookies = requireSessionCookies(cookies);
+  const directory = path.dirname(filePath);
+
+  try {
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    if (lstatSync(directory).isSymbolicLink()) {
+      throw new Error("session directory is a symbolic link");
+    }
+    if (existsSync(filePath) && lstatSync(filePath).isSymbolicLink()) {
+      throw new Error("session file is a symbolic link");
+    }
+
+    const temporaryDirectory = mkdtempSync(
+      path.join(directory, ".facebook-session-"),
+    );
+    const temporaryFile = path.join(temporaryDirectory, "snapshot.json");
+    try {
+      chmodSync(temporaryDirectory, 0o700);
+      writeFileSync(
+        temporaryFile,
+        `${JSON.stringify(
+          {
+            version: 1,
+            exportedAt: new Date().toISOString(),
+            cookies: activeCookies.map((cookie) => ({
+              name: cookie.name,
+              value: cookie.value,
+              domain: cookie.host,
+              path: cookie.path,
+              expirationDate: cookie.expires,
+              secure: cookie.secure,
+              httpOnly: cookie.httpOnly,
+            })),
+          },
+          null,
+          2,
+        )}\n`,
+        { encoding: "utf8", mode: 0o600 },
+      );
+      chmodSync(temporaryFile, 0o600);
+      renameSync(temporaryFile, filePath);
+      chmodSync(filePath, 0o600);
+    } finally {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  } catch {
+    throw new Error(
+      `Could not persist Facebook cookies to ${filePath}. Check that the session path is writable and not a symbolic link.`,
+    );
   }
 }
 
@@ -273,7 +357,6 @@ export function loadFacebookCookies(options: {
 }): FacebookCookie[] {
   const extractChrome = options.extractChrome ?? extractChromeCookies;
 
-  console.log(options.chromeProfile, "chromeProfile");
   if (!options.sessionFile) {
     return extractChrome("facebook.com", options.chromeProfile);
   }
@@ -282,7 +365,11 @@ export function loadFacebookCookies(options: {
     return loadFacebookCookiesFromFile(options.sessionFile);
   } catch (fileError) {
     try {
-      return extractChrome("facebook.com", options.chromeProfile);
+      const cookies = requireSessionCookies(
+        extractChrome("facebook.com", options.chromeProfile),
+      );
+      saveFacebookCookiesToFile(options.sessionFile, cookies);
+      return cookies;
     } catch (chromeError) {
       const fileMessage =
         fileError instanceof Error ? fileError.message : "unknown file error";
@@ -291,7 +378,7 @@ export function loadFacebookCookies(options: {
           ? chromeError.message
           : "unknown Chrome error";
       throw new Error(
-        `Could not load Facebook cookies from FACEBOOK_SESSION_FILE (${fileMessage}) or Chrome (${chromeMessage}).`,
+        `Could not load Facebook cookies from FACEBOOK_SESSION_FILE (${fileMessage}) or Chrome (${chromeMessage}). Run npm run login after signing in to Facebook.`,
       );
     }
   }

--- a/src/facebook/auth.ts
+++ b/src/facebook/auth.ts
@@ -27,8 +27,6 @@ export const DEFAULT_FACEBOOK_SESSION_FILE = path.resolve(
   ".local/facebook-session.json",
 );
 
-type CookieExtractor = (domain: string, profile?: string) => FacebookCookie[];
-
 interface CookieFileEntry {
   name?: unknown;
   value?: unknown;
@@ -234,7 +232,9 @@ export function extractChromeCookies(
 export function saveFacebookCookiesToFile(
   filePath: string,
   cookies: FacebookCookie[],
+  userAgent: string,
 ): void {
+  const browserUserAgent = requireUserAgent(userAgent);
   const activeCookies = requireSessionCookies(cookies);
   const directory = path.dirname(filePath);
 
@@ -258,6 +258,7 @@ export function saveFacebookCookiesToFile(
         `${JSON.stringify(
           {
             version: 1,
+            userAgent: browserUserAgent,
             exportedAt: new Date().toISOString(),
             cookies: activeCookies.map((cookie) => ({
               name: cookie.name,
@@ -287,13 +288,27 @@ export function saveFacebookCookiesToFile(
   }
 }
 
-/**
- * Loads cookies from a user-managed JSON file. The file may be a cookie array
- * or an object with a `cookies` array, matching common Chrome-export layouts.
- */
+interface StoredFacebookSession {
+  cookies: FacebookCookie[];
+  userAgent: string;
+}
+
+function requireUserAgent(value: unknown): string {
+  if (typeof value !== "string" || !/^[\x20-\x7e]+$/.test(value) || !value.trim()) {
+    throw new Error("Session requires a valid browser user agent. Run npm run login.");
+  }
+  return value.trim();
+}
+
 export function loadFacebookCookiesFromFile(
   filePath: string,
 ): FacebookCookie[] {
+  return loadFacebookSessionFromFile(filePath).cookies;
+}
+
+export function loadFacebookSessionFromFile(
+  filePath: string,
+): StoredFacebookSession {
   let parsed: unknown;
   try {
     parsed = JSON.parse(readFileSync(filePath, "utf8"));
@@ -301,17 +316,11 @@ export function loadFacebookCookiesFromFile(
     throw new Error("could not read valid JSON from FACEBOOK_SESSION_FILE");
   }
 
-  const entries = Array.isArray(parsed)
-    ? parsed
-    : isRecord(parsed) && Array.isArray(parsed.cookies)
-      ? parsed.cookies
-      : null;
-
-  if (!entries) {
-    throw new Error(
-      "session file must be a cookie array or an object with a cookies array",
-    );
+  if (!isRecord(parsed) || parsed.version !== 1 || !Array.isArray(parsed.cookies)) {
+    throw new Error("Invalid session format. Run npm run login.");
   }
+  const userAgent = requireUserAgent(parsed.userAgent);
+  const entries = parsed.cookies;
 
   const cookies = entries.map((entry, index): FacebookCookie => {
     if (!isRecord(entry)) {
@@ -347,40 +356,30 @@ export function loadFacebookCookiesFromFile(
     };
   });
 
-  return requireSessionCookies(cookies);
+  return {
+    cookies: requireSessionCookies(cookies),
+    userAgent,
+  };
 }
 
-export function loadFacebookCookies(options: {
+export function loadFacebookCookies(
+  options: FacebookCookieLoadOptions,
+): FacebookCookie[] {
+  return loadFacebookSession(options).cookies;
+}
+
+interface FacebookCookieLoadOptions {
   sessionFile?: string;
-  chromeProfile?: string;
-  extractChrome?: CookieExtractor;
-}): FacebookCookie[] {
-  const extractChrome = options.extractChrome ?? extractChromeCookies;
+}
 
-  if (!options.sessionFile) {
-    return extractChrome("facebook.com", options.chromeProfile);
-  }
-
+export function loadFacebookSession(
+  options: FacebookCookieLoadOptions,
+): StoredFacebookSession {
   try {
-    return loadFacebookCookiesFromFile(options.sessionFile);
-  } catch (fileError) {
-    try {
-      const cookies = requireSessionCookies(
-        extractChrome("facebook.com", options.chromeProfile),
-      );
-      saveFacebookCookiesToFile(options.sessionFile, cookies);
-      return cookies;
-    } catch (chromeError) {
-      const fileMessage =
-        fileError instanceof Error ? fileError.message : "unknown file error";
-      const chromeMessage =
-        chromeError instanceof Error
-          ? chromeError.message
-          : "unknown Chrome error";
-      throw new Error(
-        `Could not load Facebook cookies from FACEBOOK_SESSION_FILE (${fileMessage}) or Chrome (${chromeMessage}). Run npm run login after signing in to Facebook.`,
-      );
-    }
+    return loadFacebookSessionFromFile(options.sessionFile ?? DEFAULT_FACEBOOK_SESSION_FILE);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Invalid session";
+    throw new Error(`Could not load FACEBOOK_SESSION_FILE: ${message} Run npm run login.`);
   }
 }
 

--- a/src/facebook/client.ts
+++ b/src/facebook/client.ts
@@ -7,7 +7,7 @@ import type {
 import {
   cookiesToHeader,
   getCookieValue,
-  loadFacebookCookies,
+  loadFacebookSession,
 } from "./auth.js";
 import {
   MARKETPLACE_SEARCH_DOC_ID,
@@ -21,22 +21,50 @@ import { captureListingPageHtml } from "./raw-capture.js";
 import { RateLimiter } from "../utils/rate-limit.js";
 import {
   MarketplaceRequestError,
+  recordGraphqlWarning,
   type FacebookRequestContext,
 } from "../utils/diagnostics.js";
 
 const GRAPHQL_URL = "https://www.facebook.com/api/graphql/";
 const MARKETPLACE_URL = "https://www.facebook.com/marketplace/";
-
 const USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function graphqlErrorSummary(response: Record<string, unknown>) {
+  const errors = Array.isArray(response.errors)
+    ? [...response.errors]
+    : response.errors != null
+      ? [response.errors]
+      : [];
+  if (
+    response.error != null &&
+    response.error !== false &&
+    response.error !== 0
+  ) {
+    errors.push(response.error);
+  }
+  const codes: number[] = [];
+  for (const error of errors) {
+    const candidates = isRecord(error)
+      ? [
+          error.code,
+          error.error_code,
+          isRecord(error.extensions) ? error.extensions.code : undefined,
+        ]
+      : [error];
+    for (const code of candidates) {
+      if (typeof code === "number" && Number.isFinite(code)) codes.push(code);
+    }
+  }
+  return { errorCount: errors.length, codes };
+}
+
 const BROWSER_HEADERS: Record<string, string> = {
-  "User-Agent": USER_AGENT,
   "Accept-Language": "en-US,en;q=0.9",
-  "sec-ch-ua":
-    '"Chromium";v="146", "Google Chrome";v="146", "Not?A_Brand";v="99"',
-  "sec-ch-ua-mobile": "?0",
-  "sec-ch-ua-platform": '"macOS"',
   "sec-fetch-dest": "document",
   "sec-fetch-mode": "navigate",
   "sec-fetch-site": "none",
@@ -48,18 +76,16 @@ export class FacebookClient {
   private session: FacebookSession | null = null;
   private rateLimiter: RateLimiter;
   private reqCounter = 0;
-  private chromeProfile: string;
   private sessionFile?: string;
+  private userAgent = "";
 
   constructor(
     options: {
       maxRequestsPerMinute?: number;
-      chromeProfile?: string;
       sessionFile?: string;
     } = {},
   ) {
     this.rateLimiter = new RateLimiter(options.maxRequestsPerMinute ?? 3);
-    this.chromeProfile = options.chromeProfile ?? "Default";
     this.sessionFile = options.sessionFile;
   }
 
@@ -87,9 +113,8 @@ export class FacebookClient {
   }
 
   async initSession(): Promise<FacebookSession> {
-    const cookies = loadFacebookCookies({
+    const { cookies, userAgent } = loadFacebookSession({
       sessionFile: this.sessionFile,
-      chromeProfile: this.chromeProfile,
     });
 
     if (cookies.length === 0) {
@@ -105,6 +130,7 @@ export class FacebookClient {
       );
     }
 
+    this.userAgent = userAgent ?? USER_AGENT;
     const cookieHeader = cookiesToHeader(cookies);
 
     // Fetch marketplace page to extract tokens
@@ -138,6 +164,7 @@ export class FacebookClient {
       {
         headers: {
           ...BROWSER_HEADERS,
+          "User-Agent": this.userAgent,
           Cookie: cookieHeader,
           Accept:
             "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
@@ -223,6 +250,7 @@ export class FacebookClient {
         method: "POST",
         headers: {
           ...BROWSER_HEADERS,
+          "User-Agent": this.userAgent,
           Cookie: session.cookieHeader,
           "Content-Type": "application/x-www-form-urlencoded",
           Accept: "*/*",
@@ -257,22 +285,41 @@ export class FacebookClient {
       );
     }
 
-    let text = await res.text();
-
-    // Strip Facebook's anti-JSONP prefix
-    const jsonStart = text.indexOf("{");
-    if (jsonStart > 0) {
-      text = text.slice(jsonStart);
-    }
-
+    const text = await res.text();
+    const context = {
+      ...request,
+      status: res.status,
+      responseBytes: Buffer.byteLength(text, "utf8"),
+    };
+    let data: unknown;
     try {
-      return JSON.parse(text);
+      // Strip only Facebook's anti-JSONP prefix, not arbitrary non-JSON content.
+      data = JSON.parse(text.replace(/^\s*for\s*\(;;\);\s*/, ""));
     } catch {
-      throw new MarketplaceRequestError("Failed to parse GraphQL response", {
-        ...request,
-        responseBytes: text.length,
-      });
+      throw new MarketplaceRequestError(
+        "Failed to parse GraphQL response",
+        context,
+      );
     }
+    if (!isRecord(data)) {
+      throw new MarketplaceRequestError(
+        "Invalid GraphQL response envelope",
+        context,
+      );
+    }
+    const summary = graphqlErrorSummary(data);
+    if (summary.errorCount > 0) {
+      await recordGraphqlWarning(context, summary);
+    }
+    if (!isRecord(data.data)) {
+      throw new MarketplaceRequestError(
+        summary.errorCount > 0
+          ? "Facebook returned GraphQL errors without usable data"
+          : "GraphQL response is missing usable data",
+        context,
+      );
+    }
+    return data;
   }
 
   async searchListings(params: SearchParams): Promise<SearchResult> {
@@ -281,7 +328,20 @@ export class FacebookClient {
       MARKETPLACE_SEARCH_DOC_ID,
       variables,
     );
-    return parseSearchResponse(data);
+    try {
+      return parseSearchResponse(data);
+    } catch (error) {
+      throw new MarketplaceRequestError(
+        "Failed to parse Marketplace search response",
+        {
+          operation: "graphql",
+          method: "POST",
+          path: "/api/graphql/",
+          docId: MARKETPLACE_SEARCH_DOC_ID,
+        },
+        { cause: error },
+      );
+    }
   }
 
   async getListingDetail(listingId: string): Promise<MarketplaceListingDetail> {
@@ -309,6 +369,7 @@ export class FacebookClient {
       {
         headers: {
           ...BROWSER_HEADERS,
+          "User-Agent": this.userAgent,
           Cookie: session.cookieHeader,
           Accept:
             "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",

--- a/src/facebook/client.ts
+++ b/src/facebook/client.ts
@@ -17,6 +17,7 @@ import {
   buildLocationSearchVariables,
 } from "./queries.js";
 import { parseSearchResponse, parseListingDetailFromPage } from "./parser.js";
+import { captureListingPageHtml } from "./raw-capture.js";
 import { RateLimiter } from "../utils/rate-limit.js";
 import {
   MarketplaceRequestError,
@@ -317,6 +318,11 @@ export class FacebookClient {
       request,
     );
 
+    // Capture before examining the response so opted-in diagnostics retain
+    // successful pages as well as login, block, and error pages.
+    const html = await res.text();
+    await captureListingPageHtml(listingId, html);
+
     if (!res.ok) {
       throw new MarketplaceRequestError(
         `Failed to fetch listing ${listingId}: ${res.status}`,
@@ -327,7 +333,6 @@ export class FacebookClient {
       );
     }
 
-    const html = await res.text();
     try {
       return parseListingDetailFromPage(html, listingId);
     } catch (error) {

--- a/src/facebook/client.ts
+++ b/src/facebook/client.ts
@@ -18,6 +18,10 @@ import {
 } from "./queries.js";
 import { parseSearchResponse, parseListingDetailFromPage } from "./parser.js";
 import { RateLimiter } from "../utils/rate-limit.js";
+import {
+  MarketplaceRequestError,
+  type FacebookRequestContext,
+} from "../utils/diagnostics.js";
 
 const GRAPHQL_URL = "https://www.facebook.com/api/graphql/";
 const MARKETPLACE_URL = "https://www.facebook.com/marketplace/";
@@ -28,7 +32,8 @@ const USER_AGENT =
 const BROWSER_HEADERS: Record<string, string> = {
   "User-Agent": USER_AGENT,
   "Accept-Language": "en-US,en;q=0.9",
-  "sec-ch-ua": '"Chromium";v="146", "Google Chrome";v="146", "Not?A_Brand";v="99"',
+  "sec-ch-ua":
+    '"Chromium";v="146", "Google Chrome";v="146", "Not?A_Brand";v="99"',
   "sec-ch-ua-mobile": "?0",
   "sec-ch-ua-platform": '"macOS"',
   "sec-fetch-dest": "document",
@@ -50,7 +55,7 @@ export class FacebookClient {
       maxRequestsPerMinute?: number;
       chromeProfile?: string;
       sessionFile?: string;
-    } = {}
+    } = {},
   ) {
     this.rateLimiter = new RateLimiter(options.maxRequestsPerMinute ?? 3);
     this.chromeProfile = options.chromeProfile ?? "Default";
@@ -62,6 +67,24 @@ export class FacebookClient {
     return this.initSession();
   }
 
+  private async fetchFacebook(
+    url: string,
+    init: RequestInit,
+    request: FacebookRequestContext,
+  ): Promise<Response> {
+    try {
+      return await fetch(url, init);
+    } catch (error) {
+      throw new MarketplaceRequestError(
+        "Facebook request could not be completed",
+        request,
+        {
+          cause: error,
+        },
+      );
+    }
+  }
+
   async initSession(): Promise<FacebookSession> {
     const cookies = loadFacebookCookies({
       sessionFile: this.sessionFile,
@@ -70,14 +93,14 @@ export class FacebookClient {
 
     if (cookies.length === 0) {
       throw new Error(
-        "No Facebook cookies found. Provide a valid FACEBOOK_SESSION_FILE or log into Facebook in Chrome."
+        "No Facebook cookies found. Provide a valid FACEBOOK_SESSION_FILE or run npm run login.",
       );
     }
 
     const userId = getCookieValue(cookies, "c_user");
     if (!userId) {
       throw new Error(
-        "No c_user cookie found. Provide a valid FACEBOOK_SESSION_FILE or log into Facebook in Chrome."
+        "No c_user cookie found. Provide a valid FACEBOOK_SESSION_FILE or run npm run login.",
       );
     }
 
@@ -104,19 +127,29 @@ export class FacebookClient {
   }> {
     await this.rateLimiter.wait();
 
-    const res = await fetch(MARKETPLACE_URL, {
-      headers: {
-        ...BROWSER_HEADERS,
-        Cookie: cookieHeader,
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+    const request = {
+      operation: "marketplace-bootstrap" as const,
+      method: "GET" as const,
+      path: "/marketplace/",
+    };
+    const res = await this.fetchFacebook(
+      MARKETPLACE_URL,
+      {
+        headers: {
+          ...BROWSER_HEADERS,
+          Cookie: cookieHeader,
+          Accept:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        },
+        redirect: "follow",
       },
-      redirect: "follow",
-    });
+      request,
+    );
 
     if (!res.ok) {
-      throw new Error(
-        `Failed to fetch marketplace page: ${res.status} ${res.statusText}`
+      throw new MarketplaceRequestError(
+        `Failed to fetch marketplace page: ${res.status} ${res.statusText}`,
+        { ...request, status: res.status },
       );
     }
 
@@ -125,12 +158,15 @@ export class FacebookClient {
     // Extract fb_dtsg from DTSGInitData or DTSGInitialData
     const dtsgMatch =
       html.match(/"DTSGInitData"\s*,\s*\[\]\s*,\s*\{"token"\s*:\s*"([^"]+)"/) ??
-      html.match(/"DTSGInitialData"\s*,\s*\[\]\s*,\s*\{"token"\s*:\s*"([^"]+)"/) ??
+      html.match(
+        /"DTSGInitialData"\s*,\s*\[\]\s*,\s*\{"token"\s*:\s*"([^"]+)"/,
+      ) ??
       html.match(/"dtsg"\s*:\s*\{"token"\s*:\s*"([^"]+)"/);
 
     if (!dtsgMatch) {
-      throw new Error(
-        "Failed to extract fb_dtsg token. Session may be expired — try logging into Facebook in Chrome again."
+      throw new MarketplaceRequestError(
+        "Failed to extract Facebook page tokens. Session may be expired — run npm run login.",
+        { ...request, responseBytes: html.length },
       );
     }
     const fbDtsg = dtsgMatch[1];
@@ -140,12 +176,14 @@ export class FacebookClient {
     const jazoest = jazoestMatch ? jazoestMatch[1] : "";
 
     // Extract lsd
-    const lsdMatch = html.match(/"LSD"\s*,\s*\[\]\s*,\s*\{"token"\s*:\s*"([^"]+)"/) ??
+    const lsdMatch =
+      html.match(/"LSD"\s*,\s*\[\]\s*,\s*\{"token"\s*:\s*"([^"]+)"/) ??
       html.match(/name="lsd"\s+value="([^"]+)"/);
     const lsd = lsdMatch ? lsdMatch[1] : "";
 
     // Extract client revision
-    const revMatch = html.match(/"client_revision"\s*:\s*(\d+)/) ??
+    const revMatch =
+      html.match(/"client_revision"\s*:\s*(\d+)/) ??
       html.match(/__spin_r:\s*(\d+)/);
     const clientRevision = revMatch ? revMatch[1] : "1";
 
@@ -154,7 +192,7 @@ export class FacebookClient {
 
   private async graphqlRequest(
     docId: string,
-    variables: Record<string, unknown>
+    variables: Record<string, unknown>,
   ): Promise<unknown> {
     const session = await this.ensureSession();
     await this.rateLimiter.wait();
@@ -172,31 +210,50 @@ export class FacebookClient {
       __rev: session.clientRevision,
     });
 
-    const res = await fetch(GRAPHQL_URL, {
-      method: "POST",
-      headers: {
-        ...BROWSER_HEADERS,
-        Cookie: session.cookieHeader,
-        "Content-Type": "application/x-www-form-urlencoded",
-        Accept: "*/*",
-        "sec-fetch-dest": "empty",
-        "sec-fetch-mode": "cors",
-        "sec-fetch-site": "same-origin",
-        Origin: "https://www.facebook.com",
-        Referer: "https://www.facebook.com/marketplace/",
-        "X-FB-LSD": session.lsd,
+    const request = {
+      operation: "graphql" as const,
+      method: "POST" as const,
+      path: "/api/graphql/",
+      docId,
+    };
+    const res = await this.fetchFacebook(
+      GRAPHQL_URL,
+      {
+        method: "POST",
+        headers: {
+          ...BROWSER_HEADERS,
+          Cookie: session.cookieHeader,
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "*/*",
+          "sec-fetch-dest": "empty",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-site": "same-origin",
+          Origin: "https://www.facebook.com",
+          Referer: "https://www.facebook.com/marketplace/",
+          "X-FB-LSD": session.lsd,
+        },
+        body: body.toString(),
       },
-      body: body.toString(),
-    });
+      request,
+    );
 
     if (res.status === 401 || res.status === 403) {
       // Session expired — clear and retry once
       this.session = null;
-      throw new Error("Session expired. Re-initializing on next request.");
+      throw new MarketplaceRequestError(
+        "Session expired. Re-initializing on next request.",
+        {
+          ...request,
+          status: res.status,
+        },
+      );
     }
 
     if (!res.ok) {
-      throw new Error(`GraphQL request failed: ${res.status} ${res.statusText}`);
+      throw new MarketplaceRequestError(
+        `GraphQL request failed: ${res.status} ${res.statusText}`,
+        { ...request, status: res.status },
+      );
     }
 
     let text = await res.text();
@@ -210,13 +267,19 @@ export class FacebookClient {
     try {
       return JSON.parse(text);
     } catch {
-      throw new Error(`Failed to parse GraphQL response: ${text.slice(0, 200)}`);
+      throw new MarketplaceRequestError("Failed to parse GraphQL response", {
+        ...request,
+        responseBytes: text.length,
+      });
     }
   }
 
   async searchListings(params: SearchParams): Promise<SearchResult> {
     const variables = buildSearchVariables(params);
-    const data = await this.graphqlRequest(MARKETPLACE_SEARCH_DOC_ID, variables);
+    const data = await this.graphqlRequest(
+      MARKETPLACE_SEARCH_DOC_ID,
+      variables,
+    );
     return parseSearchResponse(data);
   }
 
@@ -235,35 +298,63 @@ export class FacebookClient {
     await this.rateLimiter.wait();
 
     const url = `https://www.facebook.com/marketplace/item/${listingId}/`;
-    const res = await fetch(url, {
-      headers: {
-        ...BROWSER_HEADERS,
-        Cookie: session.cookieHeader,
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+    const request = {
+      operation: "listing-page" as const,
+      method: "GET" as const,
+      path: "/marketplace/item/:listingId/",
+    };
+    const res = await this.fetchFacebook(
+      url,
+      {
+        headers: {
+          ...BROWSER_HEADERS,
+          Cookie: session.cookieHeader,
+          Accept:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        },
+        redirect: "follow",
       },
-      redirect: "follow",
-    });
+      request,
+    );
 
     if (!res.ok) {
-      throw new Error(`Failed to fetch listing ${listingId}: ${res.status}`);
+      throw new MarketplaceRequestError(
+        `Failed to fetch listing ${listingId}: ${res.status}`,
+        {
+          ...request,
+          status: res.status,
+        },
+      );
     }
 
     const html = await res.text();
-    return parseListingDetailFromPage(html, listingId);
+    try {
+      return parseListingDetailFromPage(html, listingId);
+    } catch (error) {
+      throw new MarketplaceRequestError(
+        "Failed to parse listing response",
+        {
+          ...request,
+          responseBytes: html.length,
+        },
+        { cause: error },
+      );
+    }
   }
 
   async searchLocation(
     query: string,
-    viewerCoordinates?: { latitude: number; longitude: number }
+    viewerCoordinates?: { latitude: number; longitude: number },
   ): Promise<Array<{ name: string; latitude: number; longitude: number }>> {
     const variables = buildLocationSearchVariables(query, viewerCoordinates);
     const data = await this.graphqlRequest(LOCATION_SEARCH_DOC_ID, variables);
 
     try {
-      const results = (data as any)?.data?.city_street_search?.street_results?.edges ?? [];
+      const results =
+        (data as any)?.data?.city_street_search?.street_results?.edges ?? [];
       return results.map((edge: any) => ({
-        name: edge.node?.single_line_address ?? edge.node?.subtitle ?? "Unknown",
+        name:
+          edge.node?.single_line_address ?? edge.node?.subtitle ?? "Unknown",
         latitude: edge.node?.location?.latitude ?? 0,
         longitude: edge.node?.location?.longitude ?? 0,
       }));

--- a/src/facebook/client.ts
+++ b/src/facebook/client.ts
@@ -5,9 +5,9 @@ import type {
   MarketplaceListingDetail,
 } from "./types.js";
 import {
-  extractChromeCookies,
   cookiesToHeader,
   getCookieValue,
+  loadFacebookCookies,
 } from "./auth.js";
 import {
   MARKETPLACE_SEARCH_DOC_ID,
@@ -43,15 +43,18 @@ export class FacebookClient {
   private rateLimiter: RateLimiter;
   private reqCounter = 0;
   private chromeProfile: string;
+  private sessionFile?: string;
 
   constructor(
     options: {
       maxRequestsPerMinute?: number;
       chromeProfile?: string;
+      sessionFile?: string;
     } = {}
   ) {
     this.rateLimiter = new RateLimiter(options.maxRequestsPerMinute ?? 3);
     this.chromeProfile = options.chromeProfile ?? "Default";
+    this.sessionFile = options.sessionFile;
   }
 
   async ensureSession(): Promise<FacebookSession> {
@@ -60,18 +63,21 @@ export class FacebookClient {
   }
 
   async initSession(): Promise<FacebookSession> {
-    const cookies = extractChromeCookies("facebook.com", this.chromeProfile);
+    const cookies = loadFacebookCookies({
+      sessionFile: this.sessionFile,
+      chromeProfile: this.chromeProfile,
+    });
 
     if (cookies.length === 0) {
       throw new Error(
-        "No Facebook cookies found in Chrome. Make sure you're logged into Facebook in Chrome."
+        "No Facebook cookies found. Provide a valid FACEBOOK_SESSION_FILE or log into Facebook in Chrome."
       );
     }
 
     const userId = getCookieValue(cookies, "c_user");
     if (!userId) {
       throw new Error(
-        "No c_user cookie found. Make sure you're logged into Facebook in Chrome."
+        "No c_user cookie found. Provide a valid FACEBOOK_SESSION_FILE or log into Facebook in Chrome."
       );
     }
 
@@ -248,9 +254,10 @@ export class FacebookClient {
   }
 
   async searchLocation(
-    query: string
+    query: string,
+    viewerCoordinates?: { latitude: number; longitude: number }
   ): Promise<Array<{ name: string; latitude: number; longitude: number }>> {
-    const variables = buildLocationSearchVariables(query);
+    const variables = buildLocationSearchVariables(query, viewerCoordinates);
     const data = await this.graphqlRequest(LOCATION_SEARCH_DOC_ID, variables);
 
     try {

--- a/src/facebook/login.ts
+++ b/src/facebook/login.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env tsx
+
+import { createInterface } from "node:readline/promises";
+import { chmodSync, lstatSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { chromium } from "playwright";
+import {
+  DEFAULT_FACEBOOK_SESSION_FILE,
+  saveFacebookCookiesToFile,
+} from "./auth.js";
+import type { FacebookCookie } from "./types.js";
+
+const MARKETPLACE_URL = "https://www.facebook.com/marketplace/";
+const DEFAULT_LOGIN_PROFILE_DIRECTORY = path.resolve(
+  process.cwd(),
+  ".local/facebook-login-profile",
+);
+
+interface LoginCookie {
+  domain: string;
+  name: string;
+  value: string;
+  path: string;
+  expires: number;
+  secure: boolean;
+  httpOnly: boolean;
+}
+
+interface LoginResponse {
+  ok(): boolean;
+  url(): string;
+}
+
+interface LoginPage {
+  goto(
+    url: string,
+    options: { waitUntil: "domcontentloaded"; timeout: number },
+  ): Promise<LoginResponse | null>;
+}
+
+interface LoginContext {
+  pages(): LoginPage[];
+  newPage(): Promise<LoginPage>;
+  cookies(urls: string[]): Promise<LoginCookie[]>;
+  close(): Promise<void>;
+}
+
+type LoginLauncher = (profileDirectory: string) => Promise<LoginContext>;
+
+export interface FacebookLoginOptions {
+  loginProfileDirectory?: string;
+  sessionFile?: string;
+  launch?: LoginLauncher;
+  waitForConfirmation?: () => Promise<void>;
+  writeOutput?: (message: string) => void;
+}
+
+function isFacebookMarketplaceUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    return (
+      (host === "facebook.com" || host.endsWith(".facebook.com")) &&
+      parsed.pathname.startsWith("/marketplace")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function ensurePrivateLoginProfile(profileDirectory: string): void {
+  mkdirSync(profileDirectory, { recursive: true, mode: 0o700 });
+  if (lstatSync(profileDirectory).isSymbolicLink()) {
+    throw new Error("Facebook login profile must not be a symbolic link.");
+  }
+  chmodSync(profileDirectory, 0o700);
+}
+
+export function normalizeFacebookLoginCookies(
+  cookies: LoginCookie[],
+): FacebookCookie[] {
+  return cookies
+    .filter((cookie) => {
+      const domain = cookie.domain.toLowerCase().replace(/^\./, "");
+      return domain === "facebook.com" || domain.endsWith(".facebook.com");
+    })
+    .map((cookie) => ({
+      host: cookie.domain,
+      name: cookie.name,
+      value: cookie.value,
+      path: cookie.path || "/",
+      expires: cookie.expires > 0 ? Math.floor(cookie.expires) : 0,
+      secure: cookie.secure,
+      httpOnly: cookie.httpOnly,
+    }));
+}
+
+async function launchChrome(profileDirectory: string): Promise<LoginContext> {
+  return chromium.launchPersistentContext(profileDirectory, {
+    channel: "chrome",
+    headless: false,
+    args: ["--disable-blink-features=AutomationControlled"],
+  });
+}
+
+async function waitForTerminalConfirmation(): Promise<void> {
+  const terminal = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  try {
+    await terminal.question(
+      "Finish Facebook login, return to Marketplace, then press Enter to save the session. ",
+    );
+  } finally {
+    terminal.close();
+  }
+}
+
+function assertHealthyMarketplace(response: LoginResponse | null): void {
+  if (!response?.ok() || !isFacebookMarketplaceUrl(response.url())) {
+    throw new Error(
+      "Marketplace is not authenticated. Complete any Facebook login or checkpoint, return to Marketplace, then run npm run login again.",
+    );
+  }
+}
+
+export async function runFacebookLogin(
+  options: FacebookLoginOptions = {},
+): Promise<void> {
+  const profileDirectory =
+    options.loginProfileDirectory ?? DEFAULT_LOGIN_PROFILE_DIRECTORY;
+  const sessionFile = options.sessionFile ?? DEFAULT_FACEBOOK_SESSION_FILE;
+  const launch = options.launch ?? launchChrome;
+  const waitForConfirmation =
+    options.waitForConfirmation ?? waitForTerminalConfirmation;
+  const writeOutput = options.writeOutput ?? console.log;
+
+  ensurePrivateLoginProfile(profileDirectory);
+
+  let context: LoginContext | undefined;
+  try {
+    context = await launch(profileDirectory);
+    const page = context.pages()[0] ?? (await context.newPage());
+
+    writeOutput(
+      "Opening Facebook Marketplace in a dedicated Chrome profile...",
+    );
+    await page.goto(MARKETPLACE_URL, {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+    await waitForConfirmation();
+
+    const response = await page.goto(MARKETPLACE_URL, {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+    assertHealthyMarketplace(response);
+
+    const cookies = normalizeFacebookLoginCookies(
+      await context.cookies([MARKETPLACE_URL]),
+    );
+    saveFacebookCookiesToFile(sessionFile, cookies);
+    writeOutput(`Saved Facebook session cookies to ${sessionFile}.`);
+  } finally {
+    await context?.close().catch(() => undefined);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runFacebookLogin().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : "unknown error";
+    console.error(`Facebook login failed: ${message}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/facebook/login.ts
+++ b/src/facebook/login.ts
@@ -33,6 +33,7 @@ interface LoginResponse {
 }
 
 interface LoginPage {
+  evaluate(pageFunction: () => string): Promise<string>;
   goto(
     url: string,
     options: { waitUntil: "domcontentloaded"; timeout: number },
@@ -162,7 +163,8 @@ export async function runFacebookLogin(
     const cookies = normalizeFacebookLoginCookies(
       await context.cookies([MARKETPLACE_URL]),
     );
-    saveFacebookCookiesToFile(sessionFile, cookies);
+    const userAgent = await page.evaluate(() => navigator.userAgent);
+    saveFacebookCookiesToFile(sessionFile, cookies, userAgent);
     writeOutput(`Saved Facebook session cookies to ${sessionFile}.`);
   } finally {
     await context?.close().catch(() => undefined);

--- a/src/facebook/parser.ts
+++ b/src/facebook/parser.ts
@@ -11,7 +11,8 @@ function isRecord(value: unknown): value is JsonRecord {
 }
 
 function textValue(value: unknown): string {
-  if (typeof value === "string" || typeof value === "number") return String(value);
+  if (typeof value === "string" || typeof value === "number")
+    return String(value);
   if (isRecord(value) && typeof value.text === "string") return value.text;
   return "";
 }
@@ -20,12 +21,13 @@ function findListingConnection(root: unknown): JsonRecord | null {
   const seen = new Set<object>();
   const queue: unknown[] = [root];
 
-  while (queue.length > 0) {
-    const current = queue.shift();
-    if (!isRecord(current) || seen.has(current)) continue;
+  for (let index = 0; index < queue.length; index++) {
+    const current = queue[index];
+    if ((!isRecord(current) && !Array.isArray(current)) || seen.has(current))
+      continue;
     seen.add(current);
 
-    if (Array.isArray(current.edges)) {
+    if (isRecord(current) && Array.isArray(current.edges)) {
       const hasListing = current.edges.some((edge) => {
         if (!isRecord(edge) || !isRecord(edge.node)) return false;
         return (
@@ -36,61 +38,95 @@ function findListingConnection(root: unknown): JsonRecord | null {
       if (hasListing) return current;
     }
 
-    queue.push(...Object.values(current));
+    for (const value of Object.values(current)) queue.push(value);
   }
 
   return null;
 }
 
 export function parseSearchResponse(data: unknown): SearchResult {
-  try {
-    const root = data as any;
-    const feedUnits =
-      root?.data?.marketplace_search?.feed_units ??
-      findListingConnection(root?.data);
-
-    if (!feedUnits) {
-      return { listings: [], hasNextPage: false, endCursor: null };
-    }
-
-    const edges = feedUnits.edges ?? [];
-    const pageInfo = feedUnits.page_info ?? {};
-
-    const listings: MarketplaceListing[] = edges
-      .map((edge: any) => {
-        const listing = edge?.node?.listing ?? edge?.node;
-        if (!listing?.marketplace_listing_title && !listing?.id) return null;
-
-        return {
-          id: listing.id ?? "",
-          title: listing.marketplace_listing_title ?? "",
-          price:
-            listing.listing_price?.formatted_amount ??
-            listing.listing_price?.amount ??
-            "N/A",
-          location:
-            listing.location?.reverse_geocode?.city_page?.display_name ??
-            listing.location?.reverse_geocode?.city ??
-            "Unknown",
-          imageUrl: listing.primary_listing_photo?.image?.uri ?? "",
-          sellerName: listing.marketplace_listing_seller?.name ?? "Unknown",
-          postedDate: listing.creation_time
-            ? new Date(listing.creation_time * 1000).toISOString()
-            : "",
-          url: `https://www.facebook.com/marketplace/item/${listing.id}/`,
-          isPending: listing.is_pending ?? false,
-        };
-      })
-      .filter(Boolean) as MarketplaceListing[];
-
-    return {
-      listings,
-      hasNextPage: pageInfo.has_next_page ?? false,
-      endCursor: pageInfo.end_cursor ?? null,
-    };
-  } catch {
-    return { listings: [], hasNextPage: false, endCursor: null };
+  if (!isRecord(data) || !isRecord(data.data)) {
+    throw new Error("Marketplace search response is missing data");
   }
+  const search = data.data.marketplace_search;
+  const feedUnits =
+    (isRecord(search) ? search.feed_units : undefined) ??
+    findListingConnection(data.data);
+
+  if (!isRecord(feedUnits)) {
+    throw new Error(
+      "Marketplace search response is missing a listing connection",
+    );
+  }
+  if (!Array.isArray(feedUnits.edges)) {
+    throw new Error("Marketplace listing connection has invalid edges");
+  }
+
+  const listings = feedUnits.edges
+    .map(parseSearchListing)
+    .filter((listing): listing is MarketplaceListing => listing !== null);
+  if (feedUnits.edges.length > 0 && listings.length === 0) {
+    throw new Error(
+      "Marketplace listing connection contains no usable listings",
+    );
+  }
+
+  const pageInfo = isRecord(feedUnits.page_info) ? feedUnits.page_info : {};
+  return {
+    listings,
+    hasNextPage: pageInfo.has_next_page === true,
+    endCursor:
+      typeof pageInfo.end_cursor === "string" ? pageInfo.end_cursor : null,
+  };
+}
+
+function parseSearchListing(edge: unknown): MarketplaceListing | null {
+  if (!isRecord(edge) || !isRecord(edge.node)) return null;
+  const listing = edge.node.listing ?? edge.node;
+  if (!isRecord(listing)) return null;
+  const id =
+    typeof listing.id === "string"
+      ? listing.id
+      : typeof listing.id === "number" && Number.isFinite(listing.id)
+        ? String(listing.id)
+        : "";
+  if (!id.trim()) return null;
+
+  const price = isRecord(listing.listing_price) ? listing.listing_price : {};
+  const location = isRecord(listing.location) ? listing.location : {};
+  const geocode = isRecord(location.reverse_geocode)
+    ? location.reverse_geocode
+    : {};
+  const cityPage = isRecord(geocode.city_page) ? geocode.city_page : {};
+  const photo = isRecord(listing.primary_listing_photo)
+    ? listing.primary_listing_photo
+    : {};
+  const image = isRecord(photo.image) ? photo.image : {};
+  const seller = isRecord(listing.marketplace_listing_seller)
+    ? listing.marketplace_listing_seller
+    : {};
+  const timestamp = listing.creation_time;
+  const seconds =
+    typeof timestamp === "number"
+      ? timestamp
+      : typeof timestamp === "string" && timestamp.trim() !== ""
+        ? Number(timestamp)
+        : NaN;
+  const date = new Date(seconds * 1000);
+
+  return {
+    id,
+    title: textValue(listing.marketplace_listing_title),
+    price:
+      textValue(price.formatted_amount) || textValue(price.amount) || "N/A",
+    location:
+      textValue(cityPage.display_name) || textValue(geocode.city) || "Unknown",
+    imageUrl: textValue(image.uri),
+    sellerName: textValue(seller.name) || "Unknown",
+    postedDate: Number.isFinite(date.getTime()) ? date.toISOString() : "",
+    url: `https://www.facebook.com/marketplace/item/${id}/`,
+    isPending: listing.is_pending === true,
+  };
 }
 
 function isListingNode(value: JsonRecord): boolean {
@@ -120,9 +156,12 @@ function mergeMissing(target: JsonRecord, source: JsonRecord): void {
   }
 }
 
-function findListingNodeInPage(html: string, listingId: string): JsonRecord | null {
+function findListingNodeInPage(
+  html: string,
+  listingId: string,
+): JsonRecord | null {
   const blocks = html.matchAll(
-    /<script[^>]+type=["']application\/json["'][^>]*>(.*?)<\/script>/gis
+    /<script[^>]+type=["']application\/json["'][^>]*>(.*?)<\/script>/gis,
   );
   const candidates: JsonRecord[] = [];
   const listingIds = new Set([listingId]);
@@ -139,7 +178,8 @@ function findListingNodeInPage(html: string, listingId: string): JsonRecord | nu
     const queue: unknown[] = [payload];
     for (let index = 0; index < queue.length; index++) {
       const current = queue[index];
-      if ((!isRecord(current) && !Array.isArray(current)) || seen.has(current)) continue;
+      if ((!isRecord(current) && !Array.isArray(current)) || seen.has(current))
+        continue;
       seen.add(current);
 
       if (isRecord(current) && isListingNode(current)) {
@@ -171,7 +211,7 @@ function findListingNodeInPage(html: string, listingId: string): JsonRecord | nu
 
 export function parseListingDetailFromPage(
   html: string,
-  listingId: string
+  listingId: string,
 ): MarketplaceListingDetail {
   // Facebook embeds listing data as JSON in script tags.
   // Look for structured data or relay-style data payloads.
@@ -197,7 +237,9 @@ export function parseListingDetailFromPage(
   const listing = findListingNodeInPage(html, listingId);
   if (listing) {
     detail.title = textValue(listing.marketplace_listing_title);
-    const price = isRecord(listing.listing_price) ? listing.listing_price : undefined;
+    const price = isRecord(listing.listing_price)
+      ? listing.listing_price
+      : undefined;
     detail.price =
       textValue(price?.formatted_amount_zeros_stripped) ||
       textValue(price?.formatted_amount) ||
@@ -210,7 +252,11 @@ export function parseListingDetailFromPage(
       ? reverseGeocode.city_page
       : undefined;
     detail.location =
-      textValue(isRecord(listing.location_text) ? listing.location_text.text : undefined) ||
+      textValue(
+        isRecord(listing.location_text)
+          ? listing.location_text.text
+          : undefined,
+      ) ||
       textValue(cityPage?.display_name) ||
       textValue(reverseGeocode?.city);
     detail.description = textValue(
@@ -218,7 +264,7 @@ export function parseListingDetailFromPage(
         ? listing.redacted_description.text
         : isRecord(listing.description)
           ? listing.description.text
-          : undefined
+          : undefined,
     );
     const seller = isRecord(listing.marketplace_listing_seller)
       ? listing.marketplace_listing_seller
@@ -226,11 +272,14 @@ export function parseListingDetailFromPage(
     detail.sellerName = textValue(seller?.name);
     detail.seller.name = detail.sellerName;
     const sellerId = textValue(seller?.id);
-    if (sellerId) detail.seller.profileUrl = `https://www.facebook.com/${sellerId}`;
-    detail.condition = textValue(listing.condition) || textValue(listing.condition_text);
+    if (sellerId)
+      detail.seller.profileUrl = `https://www.facebook.com/${sellerId}`;
+    detail.condition =
+      textValue(listing.condition) || textValue(listing.condition_text);
     if (!detail.condition && Array.isArray(listing.attribute_data)) {
       const condition = listing.attribute_data.find(
-        (attribute) => isRecord(attribute) && attribute.attribute_name === "Condition"
+        (attribute) =>
+          isRecord(attribute) && attribute.attribute_name === "Condition",
       );
       if (isRecord(condition)) detail.condition = textValue(condition.label);
     }
@@ -241,7 +290,9 @@ export function parseListingDetailFromPage(
     const primaryPhoto = isRecord(listing.primary_listing_photo)
       ? listing.primary_listing_photo
       : undefined;
-    const primaryImage = isRecord(primaryPhoto?.image) ? primaryPhoto.image : undefined;
+    const primaryImage = isRecord(primaryPhoto?.image)
+      ? primaryPhoto.image
+      : undefined;
     const primaryUri = textValue(primaryImage?.uri);
     if (primaryUri) {
       detail.imageUrl = primaryUri;
@@ -249,7 +300,8 @@ export function parseListingDetailFromPage(
     }
     if (Array.isArray(listing.listing_photos)) {
       for (const photo of listing.listing_photos) {
-        const image = isRecord(photo) && isRecord(photo.image) ? photo.image : undefined;
+        const image =
+          isRecord(photo) && isRecord(photo.image) ? photo.image : undefined;
         const uri = textValue(image?.uri);
         if (uri && !detail.images.includes(uri)) detail.images.push(uri);
       }
@@ -260,17 +312,19 @@ export function parseListingDetailFromPage(
   // Open Graph metadata belongs to the current page and is a safe fallback for
   // title, description, and hero-image fields when Relay markup changes.
   const titleMatch = html.match(
-    /<meta\s+property="og:title"\s+content="([^"]*)"/
+    /<meta\s+property="og:title"\s+content="([^"]*)"/,
   );
-  if (!detail.title && titleMatch) detail.title = decodeHtmlEntities(titleMatch[1]);
+  if (!detail.title && titleMatch)
+    detail.title = decodeHtmlEntities(titleMatch[1]);
 
   const descMatch = html.match(
-    /<meta\s+property="og:description"\s+content="([^"]*)"/
+    /<meta\s+property="og:description"\s+content="([^"]*)"/,
   );
-  if (!detail.description && descMatch) detail.description = decodeHtmlEntities(descMatch[1]);
+  if (!detail.description && descMatch)
+    detail.description = decodeHtmlEntities(descMatch[1]);
 
   const imageMatch = html.match(
-    /<meta\s+property="og:image"\s+content="([^"]*)"/
+    /<meta\s+property="og:image"\s+content="([^"]*)"/,
   );
   if (!detail.imageUrl && imageMatch) {
     detail.imageUrl = decodeHtmlEntities(imageMatch[1]);

--- a/src/facebook/parser.ts
+++ b/src/facebook/parser.ts
@@ -124,8 +124,8 @@ function findListingNodeInPage(html: string, listingId: string): JsonRecord | nu
   const blocks = html.matchAll(
     /<script[^>]+type=["']application\/json["'][^>]*>(.*?)<\/script>/gis
   );
-  const merged: JsonRecord = {};
-  let matched = false;
+  const candidates: JsonRecord[] = [];
+  const listingIds = new Set([listingId]);
 
   for (const block of blocks) {
     let payload: unknown;
@@ -137,19 +137,35 @@ function findListingNodeInPage(html: string, listingId: string): JsonRecord | nu
 
     const seen = new Set<object>();
     const queue: unknown[] = [payload];
-    while (queue.length > 0) {
-      const current = queue.shift();
-      if (!isRecord(current) || seen.has(current)) continue;
+    for (let index = 0; index < queue.length; index++) {
+      const current = queue[index];
+      if ((!isRecord(current) && !Array.isArray(current)) || seen.has(current)) continue;
       seen.add(current);
 
-      if (String(current.id) === listingId && isListingNode(current)) {
-        mergeMissing(merged, current);
-        matched = true;
+      if (isRecord(current) && isListingNode(current)) {
+        candidates.push(current);
+        // The public URL can use product_item.id while Relay fragments share
+        // a different listing ID. Resolve that link before merging fragments.
+        if (
+          isRecord(current.product_item) &&
+          textValue(current.product_item.id) === listingId &&
+          textValue(current.id)
+        ) {
+          listingIds.add(textValue(current.id));
+        }
       }
       queue.push(...Object.values(current));
     }
   }
 
+  const merged: JsonRecord = {};
+  let matched = false;
+  for (const candidate of candidates) {
+    if (listingIds.has(textValue(candidate.id))) {
+      mergeMissing(merged, candidate);
+      matched = true;
+    }
+  }
   return matched ? merged : null;
 }
 
@@ -212,6 +228,12 @@ export function parseListingDetailFromPage(
     const sellerId = textValue(seller?.id);
     if (sellerId) detail.seller.profileUrl = `https://www.facebook.com/${sellerId}`;
     detail.condition = textValue(listing.condition) || textValue(listing.condition_text);
+    if (!detail.condition && Array.isArray(listing.attribute_data)) {
+      const condition = listing.attribute_data.find(
+        (attribute) => isRecord(attribute) && attribute.attribute_name === "Condition"
+      );
+      if (isRecord(condition)) detail.condition = textValue(condition.label);
+    }
     detail.isPending = listing.is_pending === true;
     if (typeof listing.creation_time === "number") {
       detail.postedDate = new Date(listing.creation_time * 1000).toISOString();
@@ -232,6 +254,7 @@ export function parseListingDetailFromPage(
         if (uri && !detail.images.includes(uri)) detail.images.push(uri);
       }
     }
+    if (!detail.imageUrl) detail.imageUrl = detail.images[0] ?? "";
   }
 
   // Open Graph metadata belongs to the current page and is a safe fallback for

--- a/src/facebook/parser.ts
+++ b/src/facebook/parser.ts
@@ -4,12 +4,50 @@ import type {
   SearchResult,
 } from "./types.js";
 
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function textValue(value: unknown): string {
+  if (typeof value === "string" || typeof value === "number") return String(value);
+  if (isRecord(value) && typeof value.text === "string") return value.text;
+  return "";
+}
+
+function findListingConnection(root: unknown): JsonRecord | null {
+  const seen = new Set<object>();
+  const queue: unknown[] = [root];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!isRecord(current) || seen.has(current)) continue;
+    seen.add(current);
+
+    if (Array.isArray(current.edges)) {
+      const hasListing = current.edges.some((edge) => {
+        if (!isRecord(edge) || !isRecord(edge.node)) return false;
+        return (
+          isRecord(edge.node.listing) ||
+          typeof edge.node.marketplace_listing_title === "string"
+        );
+      });
+      if (hasListing) return current;
+    }
+
+    queue.push(...Object.values(current));
+  }
+
+  return null;
+}
+
 export function parseSearchResponse(data: unknown): SearchResult {
   try {
     const root = data as any;
     const feedUnits =
       root?.data?.marketplace_search?.feed_units ??
-      root?.data?.marketplace_search?.feed_units;
+      findListingConnection(root?.data);
 
     if (!feedUnits) {
       return { listings: [], hasNextPage: false, endCursor: null };
@@ -20,8 +58,8 @@ export function parseSearchResponse(data: unknown): SearchResult {
 
     const listings: MarketplaceListing[] = edges
       .map((edge: any) => {
-        const listing = edge?.node?.listing;
-        if (!listing) return null;
+        const listing = edge?.node?.listing ?? edge?.node;
+        if (!listing?.marketplace_listing_title && !listing?.id) return null;
 
         return {
           id: listing.id ?? "",
@@ -55,6 +93,66 @@ export function parseSearchResponse(data: unknown): SearchResult {
   }
 }
 
+function isListingNode(value: JsonRecord): boolean {
+  return (
+    typeof value.marketplace_listing_title === "string" ||
+    isRecord(value.listing_price) ||
+    isRecord(value.redacted_description) ||
+    isRecord(value.marketplace_listing_seller) ||
+    Array.isArray(value.listing_photos)
+  );
+}
+
+function mergeMissing(target: JsonRecord, source: JsonRecord): void {
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined || value === null) continue;
+    const existing = target[key];
+    if (isRecord(existing) && isRecord(value)) {
+      mergeMissing(existing, value);
+    } else if (
+      existing === undefined ||
+      existing === null ||
+      existing === "" ||
+      (Array.isArray(existing) && existing.length === 0)
+    ) {
+      target[key] = value;
+    }
+  }
+}
+
+function findListingNodeInPage(html: string, listingId: string): JsonRecord | null {
+  const blocks = html.matchAll(
+    /<script[^>]+type=["']application\/json["'][^>]*>(.*?)<\/script>/gis
+  );
+  const merged: JsonRecord = {};
+  let matched = false;
+
+  for (const block of blocks) {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(block[1]);
+    } catch {
+      continue;
+    }
+
+    const seen = new Set<object>();
+    const queue: unknown[] = [payload];
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!isRecord(current) || seen.has(current)) continue;
+      seen.add(current);
+
+      if (String(current.id) === listingId && isListingNode(current)) {
+        mergeMissing(merged, current);
+        matched = true;
+      }
+      queue.push(...Object.values(current));
+    }
+  }
+
+  return matched ? merged : null;
+}
+
 export function parseListingDetailFromPage(
   html: string,
   listingId: string
@@ -78,62 +176,83 @@ export function parseListingDetailFromPage(
     seller: { name: "", profileUrl: "" },
   };
 
-  // Try to extract from meta tags first (most reliable)
+  // Pages contain related listings too; only use Relay nodes that match the
+  // requested ID, then merge the partial nodes Facebook emits for that item.
+  const listing = findListingNodeInPage(html, listingId);
+  if (listing) {
+    detail.title = textValue(listing.marketplace_listing_title);
+    const price = isRecord(listing.listing_price) ? listing.listing_price : undefined;
+    detail.price =
+      textValue(price?.formatted_amount_zeros_stripped) ||
+      textValue(price?.formatted_amount) ||
+      textValue(price?.amount);
+    const location = isRecord(listing.location) ? listing.location : undefined;
+    const reverseGeocode = isRecord(location?.reverse_geocode)
+      ? location.reverse_geocode
+      : undefined;
+    const cityPage = isRecord(reverseGeocode?.city_page)
+      ? reverseGeocode.city_page
+      : undefined;
+    detail.location =
+      textValue(isRecord(listing.location_text) ? listing.location_text.text : undefined) ||
+      textValue(cityPage?.display_name) ||
+      textValue(reverseGeocode?.city);
+    detail.description = textValue(
+      isRecord(listing.redacted_description)
+        ? listing.redacted_description.text
+        : isRecord(listing.description)
+          ? listing.description.text
+          : undefined
+    );
+    const seller = isRecord(listing.marketplace_listing_seller)
+      ? listing.marketplace_listing_seller
+      : undefined;
+    detail.sellerName = textValue(seller?.name);
+    detail.seller.name = detail.sellerName;
+    const sellerId = textValue(seller?.id);
+    if (sellerId) detail.seller.profileUrl = `https://www.facebook.com/${sellerId}`;
+    detail.condition = textValue(listing.condition) || textValue(listing.condition_text);
+    detail.isPending = listing.is_pending === true;
+    if (typeof listing.creation_time === "number") {
+      detail.postedDate = new Date(listing.creation_time * 1000).toISOString();
+    }
+    const primaryPhoto = isRecord(listing.primary_listing_photo)
+      ? listing.primary_listing_photo
+      : undefined;
+    const primaryImage = isRecord(primaryPhoto?.image) ? primaryPhoto.image : undefined;
+    const primaryUri = textValue(primaryImage?.uri);
+    if (primaryUri) {
+      detail.imageUrl = primaryUri;
+      detail.images.push(primaryUri);
+    }
+    if (Array.isArray(listing.listing_photos)) {
+      for (const photo of listing.listing_photos) {
+        const image = isRecord(photo) && isRecord(photo.image) ? photo.image : undefined;
+        const uri = textValue(image?.uri);
+        if (uri && !detail.images.includes(uri)) detail.images.push(uri);
+      }
+    }
+  }
+
+  // Open Graph metadata belongs to the current page and is a safe fallback for
+  // title, description, and hero-image fields when Relay markup changes.
   const titleMatch = html.match(
     /<meta\s+property="og:title"\s+content="([^"]*)"/
   );
-  if (titleMatch) detail.title = decodeHtmlEntities(titleMatch[1]);
+  if (!detail.title && titleMatch) detail.title = decodeHtmlEntities(titleMatch[1]);
 
   const descMatch = html.match(
     /<meta\s+property="og:description"\s+content="([^"]*)"/
   );
-  if (descMatch) detail.description = decodeHtmlEntities(descMatch[1]);
+  if (!detail.description && descMatch) detail.description = decodeHtmlEntities(descMatch[1]);
 
   const imageMatch = html.match(
     /<meta\s+property="og:image"\s+content="([^"]*)"/
   );
-  if (imageMatch) {
+  if (!detail.imageUrl && imageMatch) {
     detail.imageUrl = decodeHtmlEntities(imageMatch[1]);
     detail.images.push(detail.imageUrl);
   }
-
-  // Try to extract price from embedded JSON
-  const priceMatch =
-    html.match(/"formatted_amount"\s*:\s*"([^"]+)"/) ??
-    html.match(/"price"\s*:\s*"([^"]+)"/) ??
-    html.match(/\"amount\"\s*:\s*"([^"]+)"/);
-  if (priceMatch) detail.price = priceMatch[1];
-
-  // Extract additional images
-  const imageRegex = /marketplace_listing_photos.*?"uri"\s*:\s*"([^"]+)"/g;
-  let imgMatch;
-  while ((imgMatch = imageRegex.exec(html)) !== null) {
-    const url = imgMatch[1].replace(/\\\//g, "/");
-    if (!detail.images.includes(url)) {
-      detail.images.push(url);
-    }
-  }
-
-  // Extract seller name
-  const sellerMatch = html.match(
-    /"marketplace_listing_seller"\s*:\s*\{[^}]*"name"\s*:\s*"([^"]+)"/
-  );
-  if (sellerMatch) {
-    detail.sellerName = sellerMatch[1];
-    detail.seller.name = sellerMatch[1];
-  }
-
-  // Extract condition
-  const conditionMatch = html.match(
-    /"condition_text"\s*:\s*"([^"]+)"/
-  ) ?? html.match(/"condition"\s*:\s*"([^"]+)"/);
-  if (conditionMatch) detail.condition = conditionMatch[1];
-
-  // Extract location
-  const locationMatch = html.match(
-    /"location_text"\s*:\s*\{[^}]*"text"\s*:\s*"([^"]+)"/
-  ) ?? html.match(/"reverse_geocode_city"\s*:\s*"([^"]+)"/);
-  if (locationMatch) detail.location = locationMatch[1];
 
   return detail;
 }

--- a/src/facebook/queries.ts
+++ b/src/facebook/queries.ts
@@ -1,3 +1,10 @@
+import type {
+  DateListed,
+  DeliveryMethod,
+  SearchParams,
+  SearchSortBy,
+} from "./types.js";
+
 // Known GraphQL doc_ids for Facebook Marketplace.
 // These are hashed operation identifiers that Facebook rotates on deploys.
 // The values below were last community-captured on 2026-08-28. Run
@@ -17,61 +24,125 @@ export function setListingDetailDocId(docId: string) {
 const SPONSORED_DATA_FIELD_NAME_PROVIDER =
   "__relay_internal__pv__GHLShouldChangeMarketplaceSponsoredDataFieldNamerelayprovider";
 
-export function buildSearchVariables(params: {
-  query: string;
-  latitude: number;
-  longitude: number;
-  radiusKm: number;
-  minPrice?: number;
-  maxPrice?: number;
-  category?: string;
-  limit: number;
-  cursor?: string;
-}) {
+const SORT_VALUES: Record<Exclude<SearchSortBy, "suggested">, string> = {
+  distance: "DISTANCE_ASCEND",
+  date_listed: "CREATION_TIME_DESCEND",
+  price_low_to_high: "PRICE_ASCEND",
+  price_high_to_low: "PRICE_DESCEND",
+};
+
+const DELIVERY_VALUES: Record<DeliveryMethod, readonly [boolean, boolean]> = {
+  all: [true, true],
+  local_pickup: [true, false],
+  shipping: [false, true],
+};
+
+const LISTED_WITHIN_DAY_COUNTS: Record<Exclude<DateListed, "all">, number> = {
+  last_24_hours: 2,
+  last_7_days: 8,
+  last_30_days: 31,
+};
+
+export function getCurrentUtcDayIndex(now = new Date()): number {
+  return Math.floor(now.getTime() / 86_400_000);
+}
+
+export function buildDateListedWindow(
+  dateListed: DateListed,
+  currentUtcDayIndex = getCurrentUtcDayIndex(),
+): string | null {
+  if (dateListed === "all") return null;
+
+  return Array.from(
+    { length: LISTED_WITHIN_DAY_COUNTS[dateListed] },
+    (_, index) => String(currentUtcDayIndex - index),
+  ).join(";");
+}
+
+export function buildSearchVariables(params: SearchParams) {
+  const sortBy = params.sortBy ?? "suggested";
+  const deliveryMethod = params.deliveryMethod ?? "all";
+  const dateListed = params.dateListed ?? "all";
+  const [localPickup, shipping] = DELIVERY_VALUES[deliveryMethod];
   const variables: Record<string, unknown> = {
+    // Number of listings Facebook should return in this page.
     count: params.limit,
+    // Marketplace's nested search-parameter payload.
     params: {
+      // Basic query fields for the Marketplace browse-query flow.
       bqf: {
+        // Identifies this as a search made by the desktop Marketplace web surface.
         callsite: "COMMERCE_MKTPLACE_WWW",
+        // The user's Marketplace search text.
         query: params.query,
       },
+      // Filters that control which Marketplace inventory is returned.
       browse_request_params: {
-        commerce_enable_local_pickup: true,
-        commerce_enable_shipping: true,
+        // Include listings available for local collection.
+        commerce_enable_local_pickup: localPickup,
+        // Include listings that Facebook marks as shippable.
+        commerce_enable_shipping: shipping,
+        // Ask Facebook to apply its availability filter to the results.
         commerce_search_and_rp_available: true,
+        // Restrict results to the selected Marketplace category, if supplied.
         commerce_search_and_rp_category_id: params.category
           ? [params.category]
           : [],
+        // No condition filter is selected.
         commerce_search_and_rp_condition: null,
-        commerce_search_and_rp_ctime_days: null,
+        // No listed-within date filter is selected.
+        commerce_search_and_rp_ctime_days: buildDateListedWindow(dateListed),
+        // Latitude of the requested search center.
         filter_location_latitude: params.latitude,
+        // Longitude of the requested search center.
         filter_location_longitude: params.longitude,
+        // Minimum price in cents; zero leaves the lower bound unfiltered.
         filter_price_lower_bound: params.minPrice
           ? params.minPrice * 100
           : 0,
+        // Maximum price in cents; Facebook's observed maximum leaves the upper bound unfiltered.
         filter_price_upper_bound: params.maxPrice
           ? params.maxPrice * 100
           : 214748364700,
+        // Search radius around the requested coordinates, in kilometers.
         filter_radius_km: params.radiusKm,
+        // Facebook's suggested sort is represented by omitting this field.
+        ...(sortBy === "suggested"
+          ? {}
+          : { commerce_search_sort_by: SORT_VALUES[sortBy] }),
       },
+      // Web-client context retained by Facebook's persisted query contract.
       custom_request_params: {
+        // No extra browse context is supplied for this direct search request.
         browse_context: null,
+        // No contextual filters are selected.
         contextual_filters: [],
+        // This search did not originate from a Marketplace referral.
         referral_code: null,
+        // This search did not originate from a specific referral UI component.
         referral_ui_component: null,
+        // This request is not associated with a saved Marketplace search.
         saved_search_strid: null,
+        // Search Facebook's consumer-to-consumer Marketplace inventory.
         search_vertical: "C2C",
+        // No search-engine-optimized Marketplace URL context is supplied.
         seo_url: null,
+        // Do not select a virtual Marketplace category.
         serp_landing_settings: { virtual_category_id: "" },
+        // Identify the request as a Marketplace search page.
         surface: "SEARCH",
+        // No virtual contextual filters are selected.
         virtual_contextual_filters: [],
       },
     },
+    // Request images at the desktop client's observed 2x display scale.
     scale: 2,
+    // Relay feature flag observed on Marketplace search requests for sponsored-data field naming.
     [SPONSORED_DATA_FIELD_NAME_PROVIDER]: true,
   };
 
   if (params.cursor) {
+    // Continue from the opaque cursor returned by the previous result page.
     variables.cursor = params.cursor;
   }
 

--- a/src/facebook/queries.ts
+++ b/src/facebook/queries.ts
@@ -1,9 +1,10 @@
 // Known GraphQL doc_ids for Facebook Marketplace.
 // These are hashed operation identifiers that Facebook rotates on deploys.
-// Run `npm run capture-queries` to discover current values if these break.
+// The values below were last community-captured on 2026-08-28. Run
+// `npm run capture-queries` to discover current values if these break.
 
-export const MARKETPLACE_SEARCH_DOC_ID = "7111939778879383";
-export const LOCATION_SEARCH_DOC_ID = "5585904654783609";
+export const MARKETPLACE_SEARCH_DOC_ID = "27212616558440397";
+export const LOCATION_SEARCH_DOC_ID = "9660140454040174";
 
 // Listing detail uses a different approach — we extract the doc_id dynamically
 // or fall back to fetching the listing page and parsing embedded data.
@@ -12,6 +13,9 @@ export let LISTING_DETAIL_DOC_ID = "";
 export function setListingDetailDocId(docId: string) {
   LISTING_DETAIL_DOC_ID = docId;
 }
+
+const SPONSORED_DATA_FIELD_NAME_PROVIDER =
+  "__relay_internal__pv__GHLShouldChangeMarketplaceSponsoredDataFieldNamerelayprovider";
 
 export function buildSearchVariables(params: {
   query: string;
@@ -35,6 +39,9 @@ export function buildSearchVariables(params: {
         commerce_enable_local_pickup: true,
         commerce_enable_shipping: true,
         commerce_search_and_rp_available: true,
+        commerce_search_and_rp_category_id: params.category
+          ? [params.category]
+          : [],
         commerce_search_and_rp_condition: null,
         commerce_search_and_rp_ctime_days: null,
         filter_location_latitude: params.latitude,
@@ -48,36 +55,42 @@ export function buildSearchVariables(params: {
         filter_radius_km: params.radiusKm,
       },
       custom_request_params: {
+        browse_context: null,
+        contextual_filters: [],
+        referral_code: null,
+        referral_ui_component: null,
+        saved_search_strid: null,
+        search_vertical: "C2C",
+        seo_url: null,
+        serp_landing_settings: { virtual_category_id: "" },
         surface: "SEARCH",
+        virtual_contextual_filters: [],
       },
     },
+    scale: 2,
+    [SPONSORED_DATA_FIELD_NAME_PROVIDER]: true,
   };
 
   if (params.cursor) {
     variables.cursor = params.cursor;
   }
 
-  if (params.category) {
-    (
-      variables.params as Record<string, unknown>
-    ).browse_request_params = {
-      ...(
-        (variables.params as Record<string, unknown>)
-          .browse_request_params as Record<string, unknown>
-      ),
-      commerce_search_and_rp_category_id: params.category,
-    };
-  }
-
   return variables;
 }
 
-export function buildLocationSearchVariables(query: string) {
+export function buildLocationSearchVariables(
+  query: string,
+  viewerCoordinates?: { latitude: number; longitude: number }
+) {
   return {
     params: {
       caller: "MARKETPLACE",
-      page_category: ["CITY", "SUBCITY", "NEIGHBORHOOD"],
+      country_filter: null,
+      integration_strategy: "STRING_MATCH",
+      page_category: ["CITY", "SUBCITY", "NEIGHBORHOOD", "POSTAL_CODE"],
       query,
+      search_type: "PLACE_TYPEAHEAD",
+      viewer_coordinates: viewerCoordinates ?? null,
     },
   };
 }

--- a/src/facebook/raw-capture.ts
+++ b/src/facebook/raw-capture.ts
@@ -1,0 +1,57 @@
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+
+const DEFAULT_CAPTURE_DIRECTORY = ".local/listing-page-captures";
+
+export type ListingPageCaptureOptions = {
+  enabled?: boolean;
+  directory?: string;
+};
+
+function captureEnabled(options: ListingPageCaptureOptions): boolean {
+  return options.enabled ?? process.env.MCP_CAPTURE_LISTING_HTML === "1";
+}
+
+function captureDirectory(options: ListingPageCaptureOptions): string {
+  return resolve(
+    options.directory ??
+      process.env.MCP_LISTING_CAPTURE_DIR ??
+      DEFAULT_CAPTURE_DIRECTORY,
+  );
+}
+
+function filenamePart(value: string): string {
+  const safeValue = value.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 80);
+  return safeValue || "listing";
+}
+
+/**
+ * Saves an exact listing-page response only when explicitly enabled. Captures
+ * are deliberately separate from sanitized MCP diagnostics and never affect a
+ * Marketplace request when local storage is unavailable.
+ */
+export async function captureListingPageHtml(
+  listingId: string,
+  html: string,
+  options: ListingPageCaptureOptions = {},
+): Promise<void> {
+  if (!captureEnabled(options)) return;
+
+  try {
+    const directory = captureDirectory(options);
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await chmod(directory, 0o700);
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const path = resolve(
+      directory,
+      `${timestamp}-${filenamePart(listingId)}-${randomUUID()}.html`,
+    );
+    await writeFile(path, html, { encoding: "utf8", mode: 0o600, flag: "wx" });
+  } catch {
+    process.stderr.write(
+      "[facebook-marketplace-mcp] could not capture listing page HTML\n",
+    );
+  }
+}

--- a/src/facebook/types.ts
+++ b/src/facebook/types.ts
@@ -40,6 +40,21 @@ export interface MarketplaceListingDetail extends MarketplaceListing {
   };
 }
 
+export type SearchSortBy =
+  | "suggested"
+  | "distance"
+  | "date_listed"
+  | "price_low_to_high"
+  | "price_high_to_low";
+
+export type DeliveryMethod = "all" | "local_pickup" | "shipping";
+
+export type DateListed =
+  | "all"
+  | "last_24_hours"
+  | "last_7_days"
+  | "last_30_days";
+
 export interface SearchParams {
   query: string;
   latitude: number;
@@ -48,6 +63,9 @@ export interface SearchParams {
   minPrice?: number;
   maxPrice?: number;
   category?: string;
+  sortBy?: SearchSortBy;
+  deliveryMethod?: DeliveryMethod;
+  dateListed?: DateListed;
   limit: number;
   cursor?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,6 @@ import { localMonitorStore } from "./mcp/monitor-store.js";
 
 const client = new FacebookClient({
   maxRequestsPerMinute: 3,
-  chromeProfile: process.env.CHROME_PROFILE ?? "Profile 1",
   sessionFile: process.env.FACEBOOK_SESSION_FILE ?? DEFAULT_FACEBOOK_SESSION_FILE,
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 const client = new FacebookClient({
   maxRequestsPerMinute: 3,
   chromeProfile: process.env.CHROME_PROFILE ?? "Default",
+  sessionFile: process.env.FACEBOOK_SESSION_FILE,
 });
 
 const server = new McpServer({
@@ -35,7 +36,7 @@ server.tool(
   "search_listings",
   "Search Facebook Marketplace listings by query, location, and filters",
   searchListingsSchema,
-  createSearchHandler(client)
+  createSearchHandler(client),
 );
 
 // Get listing details
@@ -43,7 +44,7 @@ server.tool(
   "get_listing",
   "Get full details for a specific Facebook Marketplace listing",
   getListingSchema,
-  createListingHandler(client)
+  createListingHandler(client),
 );
 
 // Search for a location (get coordinates)
@@ -51,7 +52,7 @@ server.tool(
   "search_location",
   "Look up a city/town name to get coordinates for use with search_listings",
   searchLocationSchema,
-  createLocationHandler(client)
+  createLocationHandler(client),
 );
 
 // Save a search monitor
@@ -59,7 +60,7 @@ server.tool(
   "monitor_search",
   "Save a search query as a monitor to track new listings over time",
   monitorSearchSchema,
-  createMonitorSearchHandler()
+  createMonitorSearchHandler(),
 );
 
 // Check monitors for new listings
@@ -67,7 +68,7 @@ server.tool(
   "check_monitors",
   "Check saved monitors for new listings since last check",
   checkMonitorsSchema,
-  createCheckMonitorsHandler(client)
+  createCheckMonitorsHandler(client),
 );
 
 // Delete a monitor
@@ -75,7 +76,7 @@ server.tool(
   "delete_monitor",
   "Delete a saved search monitor",
   deleteMonitorSchema,
-  createDeleteMonitorHandler()
+  createDeleteMonitorHandler(),
 );
 
 // List all monitors
@@ -83,7 +84,7 @@ server.tool(
   "list_monitors",
   "List all saved search monitors",
   listMonitorsSchema,
-  createListMonitorsHandler()
+  createListMonitorsHandler(),
 );
 
 // Start the server

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,45 @@
 #!/usr/bin/env node
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { FacebookClient } from "./facebook/client.js";
-import { searchListingsSchema, createSearchHandler } from "./tools/search.js";
-import { getListingSchema, createListingHandler } from "./tools/listing.js";
+import { DEFAULT_FACEBOOK_SESSION_FILE } from "./facebook/auth.js";
 import {
-  searchLocationSchema,
-  createLocationHandler,
-} from "./tools/location.js";
-import {
-  monitorSearchSchema,
-  checkMonitorsSchema,
-  deleteMonitorSchema,
-  listMonitorsSchema,
-  createMonitorSearchHandler,
   createCheckMonitorsHandler,
+  createCreateMonitorHandler,
   createDeleteMonitorHandler,
   createListMonitorsHandler,
 } from "./tools/monitor.js";
+import {
+  checkMonitorsInput,
+  checkMonitorsOutput,
+  createMonitorInput,
+  createMonitorOutput,
+  deleteMonitorInput,
+  deleteMonitorOutput,
+  getListingInput,
+  listingOutput,
+  listMonitorsInput,
+  listMonitorsOutput,
+  locationsOutput,
+  searchListingsInput,
+  searchListingsOutput,
+  searchLocationsInput,
+} from "./mcp/contracts.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  createGetListingHandler,
+  createSearchListingsHandler,
+} from "./tools/listing.js";
+import { createSearchLocationsHandler } from "./tools/location.js";
+import { localMonitorStore } from "./mcp/monitor-store.js";
 
 const client = new FacebookClient({
   maxRequestsPerMinute: 3,
-  chromeProfile: process.env.CHROME_PROFILE ?? "Default",
-  sessionFile: process.env.FACEBOOK_SESSION_FILE,
+  chromeProfile: process.env.CHROME_PROFILE ?? "Profile 1",
+  sessionFile: process.env.FACEBOOK_SESSION_FILE ?? DEFAULT_FACEBOOK_SESSION_FILE,
 });
+
+const monitorStore = localMonitorStore;
 
 const server = new McpServer({
   name: "facebook-marketplace",
@@ -32,59 +47,135 @@ const server = new McpServer({
 });
 
 // Search listings
-server.tool(
-  "search_listings",
-  "Search Facebook Marketplace listings by query, location, and filters",
-  searchListingsSchema,
-  createSearchHandler(client),
+server.registerTool(
+  "facebook_marketplace_search_listings",
+  {
+    title: "Search Facebook Marketplace listings",
+    description:
+      "Search Marketplace listings by text, location, filters, and an optional continuation cursor.",
+    inputSchema: searchListingsInput,
+    outputSchema: searchListingsOutput,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  createSearchListingsHandler(client),
 );
 
 // Get listing details
-server.tool(
-  "get_listing",
-  "Get full details for a specific Facebook Marketplace listing",
-  getListingSchema,
-  createListingHandler(client),
+server.registerTool(
+  "facebook_marketplace_get_listing",
+  {
+    title: "Get a Facebook Marketplace listing",
+    description:
+      "Get details, seller information, and images for one Marketplace listing.",
+    inputSchema: getListingInput,
+    outputSchema: listingOutput,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  createGetListingHandler(client),
 );
 
 // Search for a location (get coordinates)
-server.tool(
-  "search_location",
-  "Look up a city/town name to get coordinates for use with search_listings",
-  searchLocationSchema,
-  createLocationHandler(client),
+server.registerTool(
+  "facebook_marketplace_search_locations",
+  {
+    title: "Search Marketplace locations",
+    description:
+      "Resolve a city, neighborhood, or ZIP code to coordinates for a Marketplace search.",
+    inputSchema: searchLocationsInput,
+    outputSchema: locationsOutput,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  createSearchLocationsHandler(client),
 );
 
 // Save a search monitor
-server.tool(
-  "monitor_search",
-  "Save a search query as a monitor to track new listings over time",
-  monitorSearchSchema,
-  createMonitorSearchHandler(),
+server.registerTool(
+  "facebook_marketplace_create_monitor",
+  {
+    title: "Create a Marketplace monitor",
+    description:
+      "Persist a Marketplace search locally and use it to detect new listings later.",
+    inputSchema: createMonitorInput,
+    outputSchema: createMonitorOutput,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+  },
+  createCreateMonitorHandler(monitorStore),
 );
 
 // Check monitors for new listings
-server.tool(
-  "check_monitors",
-  "Check saved monitors for new listings since last check",
-  checkMonitorsSchema,
-  createCheckMonitorsHandler(client),
+server.registerTool(
+  "facebook_marketplace_check_monitors",
+  {
+    title: "Check Marketplace monitors",
+    description:
+      "Search saved monitors and record newly observed listing IDs locally.",
+    inputSchema: checkMonitorsInput,
+    outputSchema: checkMonitorsOutput,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+  createCheckMonitorsHandler(client, monitorStore),
 );
 
 // Delete a monitor
-server.tool(
-  "delete_monitor",
-  "Delete a saved search monitor",
-  deleteMonitorSchema,
-  createDeleteMonitorHandler(),
+server.registerTool(
+  "facebook_marketplace_delete_monitor",
+  {
+    title: "Delete a Marketplace monitor",
+    description: "Permanently delete one locally saved Marketplace monitor.",
+    inputSchema: deleteMonitorInput,
+    outputSchema: deleteMonitorOutput,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  createDeleteMonitorHandler(monitorStore),
 );
 
 // List all monitors
-server.tool(
-  "list_monitors",
-  "List all saved search monitors",
-  listMonitorsSchema,
-  createListMonitorsHandler(),
+server.registerTool(
+  "facebook_marketplace_list_monitors",
+  {
+    title: "List Marketplace monitors",
+    description:
+      "List locally saved Marketplace monitors and their check state.",
+    inputSchema: listMonitorsInput,
+    outputSchema: listMonitorsOutput,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  createListMonitorsHandler(monitorStore),
 );
 
 // Start the server

--- a/src/mcp/constants.ts
+++ b/src/mcp/constants.ts
@@ -1,0 +1,3 @@
+export const CHARACTER_LIMIT = 25_000;
+export const DEFAULT_SEARCH_LIMIT = 20;
+export const MAX_SEARCH_LIMIT = 100;

--- a/src/mcp/contracts.ts
+++ b/src/mcp/contracts.ts
@@ -1,0 +1,229 @@
+import { z } from "zod";
+import { DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT } from "./constants.js";
+
+export const responseFormatSchema = z
+  .enum(["markdown", "json"])
+  .default("markdown")
+  .describe(
+    "Output format: markdown for readability or json for machine processing.",
+  );
+
+const listingSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  price: z.string(),
+  location: z.string(),
+  image_url: z.string(),
+  seller_name: z.string(),
+  posted_date: z.string(),
+  url: z.string(),
+  is_pending: z.boolean(),
+});
+
+const monitorSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  query: z.string(),
+  latitude: z.number(),
+  longitude: z.number(),
+  radius_km: z.number(),
+  min_price: z.number().optional(),
+  max_price: z.number().optional(),
+  category: z.string().optional(),
+  created_at: z.string(),
+  last_checked: z.string().nullable(),
+  seen_count: z.number().int().nonnegative(),
+});
+
+const searchFields = {
+  query: z.string().trim().min(1).max(200).describe("Marketplace search text."),
+  latitude: z.number().min(-90).max(90).describe("Search-center latitude."),
+  longitude: z.number().min(-180).max(180).describe("Search-center longitude."),
+  radius_km: z
+    .number()
+    .positive()
+    .max(1_000)
+    .default(50)
+    .describe("Search radius in kilometers."),
+  min_price: z
+    .number()
+    .nonnegative()
+    .optional()
+    .describe("Minimum price in dollars."),
+  max_price: z
+    .number()
+    .nonnegative()
+    .optional()
+    .describe("Maximum price in dollars."),
+  category: z
+    .string()
+    .trim()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("Marketplace category ID."),
+};
+
+export const searchListingsInput = z
+  .object({
+    ...searchFields,
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_SEARCH_LIMIT)
+      .default(DEFAULT_SEARCH_LIMIT)
+      .describe("Maximum listings to return."),
+    cursor: z
+      .string()
+      .min(1)
+      .max(2_000)
+      .optional()
+      .describe("Cursor returned by a prior search."),
+    response_format: responseFormatSchema,
+  })
+  .strict()
+  .superRefine(({ min_price, max_price }, context) => {
+    if (
+      min_price !== undefined &&
+      max_price !== undefined &&
+      min_price > max_price
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "min_price must not exceed max_price",
+        path: ["max_price"],
+      });
+    }
+  });
+
+export const getListingInput = z
+  .object({
+    listing_id: z
+      .string()
+      .trim()
+      .min(1)
+      .max(100)
+      .describe("Facebook Marketplace listing ID."),
+    response_format: responseFormatSchema,
+  })
+  .strict();
+
+export const searchLocationsInput = z
+  .object({
+    query: z
+      .string()
+      .trim()
+      .min(1)
+      .max(200)
+      .describe("City, neighborhood, or ZIP code."),
+    response_format: responseFormatSchema,
+  })
+  .strict();
+
+export const createMonitorInput = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1)
+      .max(100)
+      .describe("Unique saved-monitor name."),
+    ...searchFields,
+    response_format: responseFormatSchema,
+  })
+  .strict()
+  .superRefine(({ min_price, max_price }, context) => {
+    if (
+      min_price !== undefined &&
+      max_price !== undefined &&
+      min_price > max_price
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "min_price must not exceed max_price",
+        path: ["max_price"],
+      });
+    }
+  });
+
+export const checkMonitorsInput = z
+  .object({
+    monitor_name: z
+      .string()
+      .trim()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("One monitor name; omit to check all."),
+    response_format: responseFormatSchema,
+  })
+  .strict();
+
+export const deleteMonitorInput = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1)
+      .max(100)
+      .describe("Saved-monitor name to delete."),
+    response_format: responseFormatSchema,
+  })
+  .strict();
+
+export const listMonitorsInput = z
+  .object({ response_format: responseFormatSchema })
+  .strict();
+
+const truncationFields = {
+  truncated: z.boolean(),
+  truncation_message: z.string().optional(),
+};
+
+export const searchListingsOutput = z.object({
+  query: z.string(),
+  count: z.number().int().nonnegative(),
+  listings: z.array(listingSchema),
+  has_more: z.boolean(),
+  next_cursor: z.string().nullable(),
+  ...truncationFields,
+});
+export const listingOutput = z.object({
+  listing: listingSchema.extend({
+    description: z.string(),
+    images: z.array(z.string()),
+    condition: z.string(),
+    seller: z.object({ name: z.string(), profile_url: z.string().nullable() }),
+  }),
+  ...truncationFields,
+});
+export const locationsOutput = z.object({
+  query: z.string(),
+  count: z.number().int().nonnegative(),
+  locations: z.array(
+    z.object({ name: z.string(), latitude: z.number(), longitude: z.number() }),
+  ),
+  ...truncationFields,
+});
+export const createMonitorOutput = z.object({ monitor: monitorSchema });
+export const checkMonitorsOutput = z.object({
+  count: z.number().int().nonnegative(),
+  results: z.array(
+    z.object({
+      name: z.string(),
+      found: z.boolean(),
+      new_listings: z.array(listingSchema),
+    }),
+  ),
+  ...truncationFields,
+});
+export const deleteMonitorOutput = z.object({
+  name: z.string(),
+  deleted: z.boolean(),
+});
+export const listMonitorsOutput = z.object({
+  count: z.number().int().nonnegative(),
+  monitors: z.array(monitorSchema),
+  ...truncationFields,
+});

--- a/src/mcp/contracts.ts
+++ b/src/mcp/contracts.ts
@@ -67,6 +67,24 @@ const searchFields = {
 export const searchListingsInput = z
   .object({
     ...searchFields,
+    sort_by: z
+      .enum([
+        "suggested",
+        "distance",
+        "date_listed",
+        "price_low_to_high",
+        "price_high_to_low",
+      ])
+      .default("suggested")
+      .describe("Result order (default: suggested)."),
+    delivery_method: z
+      .enum(["all", "local_pickup", "shipping"])
+      .default("all")
+      .describe("Listing delivery method (default: all)."),
+    date_listed: z
+      .enum(["all", "last_24_hours", "last_7_days", "last_30_days"])
+      .default("all")
+      .describe("When listings were posted (default: all)."),
     limit: z
       .number()
       .int()

--- a/src/mcp/contracts.ts
+++ b/src/mcp/contracts.ts
@@ -1,5 +1,10 @@
-import { z } from "zod";
+// Zod 4 keeps refinements on object schemas so the MCP SDK can publish their fields.
+import { z } from "zod/v4";
 import { DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT } from "./constants.js";
+
+// Keep nullable strings constrained for JSON Schema converters that otherwise
+// collapse nullable strings into an array-valued `type`.
+const nullableStringSchema = z.string().min(0).nullable();
 
 export const responseFormatSchema = z
   .enum(["markdown", "json"])
@@ -31,7 +36,7 @@ const monitorSchema = z.object({
   max_price: z.number().optional(),
   category: z.string().optional(),
   created_at: z.string(),
-  last_checked: z.string().nullable(),
+  last_checked: nullableStringSchema,
   seen_count: z.number().int().nonnegative(),
 });
 
@@ -204,7 +209,7 @@ export const searchListingsOutput = z.object({
   count: z.number().int().nonnegative(),
   listings: z.array(listingSchema),
   has_more: z.boolean(),
-  next_cursor: z.string().nullable(),
+  next_cursor: nullableStringSchema,
   ...truncationFields,
 });
 export const listingOutput = z.object({
@@ -212,7 +217,7 @@ export const listingOutput = z.object({
     description: z.string(),
     images: z.array(z.string()),
     condition: z.string(),
-    seller: z.object({ name: z.string(), profile_url: z.string().nullable() }),
+    seller: z.object({ name: z.string(), profile_url: nullableStringSchema }),
   }),
   ...truncationFields,
 });

--- a/src/mcp/monitor-store.ts
+++ b/src/mcp/monitor-store.ts
@@ -1,0 +1,16 @@
+import {
+  addMonitor,
+  deleteMonitor,
+  getMonitor,
+  loadMonitors,
+  updateMonitorSeenIds,
+} from "../storage/monitors.js";
+import type { MonitorStore } from "./types.js";
+
+export const localMonitorStore: MonitorStore = {
+  add: addMonitor,
+  list: loadMonitors,
+  get: getMonitor,
+  updateSeenIds: updateMonitorSeenIds,
+  delete: deleteMonitor,
+};

--- a/src/mcp/response.ts
+++ b/src/mcp/response.ts
@@ -1,0 +1,48 @@
+import { CHARACTER_LIMIT } from "./constants.js";
+
+export type ResponseFormat = "markdown" | "json";
+
+export function responseFor<T extends Record<string, unknown>>(
+  output: T,
+  responseFormat: ResponseFormat,
+  markdown: string,
+) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text:
+          responseFormat === "json"
+            ? JSON.stringify(output, null, 2)
+            : truncateText(markdown).text,
+      },
+    ],
+    structuredContent: output,
+  };
+}
+
+export function truncateText(value: string): {
+  text: string;
+  truncated: boolean;
+} {
+  if (value.length <= CHARACTER_LIMIT) return { text: value, truncated: false };
+  return {
+    text: `${value.slice(0, CHARACTER_LIMIT - 120)}\n\n_Response truncated. Use a narrower query, lower limit, or returned cursor._`,
+    truncated: true,
+  };
+}
+
+export function takeWithinCharacterLimit<T>(
+  items: T[],
+  renderItem: (item: T) => string,
+): { items: T[]; truncated: boolean } {
+  const selected: T[] = [];
+  let length = 0;
+  for (const item of items) {
+    const renderedLength = renderItem(item).length;
+    if (selected.length > 0 && length + renderedLength > CHARACTER_LIMIT) break;
+    selected.push(item);
+    length += renderedLength;
+  }
+  return { items: selected, truncated: selected.length < items.length };
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,25 @@
+import type {
+  MarketplaceListing,
+  MarketplaceListingDetail,
+  SavedMonitor,
+  SearchParams,
+  SearchResult,
+} from "../facebook/types.js";
+
+export interface MarketplaceService {
+  searchListings(params: SearchParams): Promise<SearchResult>;
+  getListingDetail(listingId: string): Promise<MarketplaceListingDetail>;
+  searchLocation(
+    query: string,
+  ): Promise<Array<{ name: string; latitude: number; longitude: number }>>;
+}
+
+export interface MonitorStore {
+  add(name: string, params: Omit<SearchParams, "cursor">): SavedMonitor;
+  list(): SavedMonitor[];
+  get(name: string): SavedMonitor | undefined;
+  updateSeenIds(name: string, newIds: string[]): void;
+  delete(name: string): boolean;
+}
+
+export type { MarketplaceListing, MarketplaceListingDetail, SavedMonitor };

--- a/src/tools/listing.ts
+++ b/src/tools/listing.ts
@@ -1,54 +1,113 @@
-import { z } from "zod";
-import type { FacebookClient } from "../facebook/client.js";
+import type { z } from "zod";
+import { getListingInput, searchListingsInput } from "../mcp/contracts.js";
+import {
+  responseFor,
+  takeWithinCharacterLimit,
+  truncateText,
+} from "../mcp/response.js";
+import type { MarketplaceService } from "../mcp/types.js";
+import { toolErrorResponse } from "../utils/diagnostics.js";
+import { listingOutput, listingsMarkdown } from "./shared.js";
 
-export const getListingSchema = {
-  listing_id: z.string().describe("Facebook Marketplace listing ID"),
-};
-
-export function createListingHandler(client: FacebookClient) {
-  return async (args: { listing_id: string }) => {
+export function createSearchListingsHandler(service: MarketplaceService) {
+  return async (args: z.infer<typeof searchListingsInput>) => {
     try {
-      const listing = await client.getListingDetail(args.listing_id);
+      const result = await service.searchListings({
+        query: args.query,
+        latitude: args.latitude,
+        longitude: args.longitude,
+        radiusKm: args.radius_km,
+        minPrice: args.min_price,
+        maxPrice: args.max_price,
+        category: args.category,
+        limit: args.limit,
+        cursor: args.cursor,
+      });
+      const bounded = takeWithinCharacterLimit(
+        result.listings.map(listingOutput),
+        (listing) => JSON.stringify(listing),
+      );
+      const output = {
+        query: args.query,
+        count: bounded.items.length,
+        listings: bounded.items,
+        has_more: result.hasNextPage || bounded.truncated,
+        next_cursor: result.endCursor,
+        truncated: bounded.truncated,
+        ...(bounded.truncated
+          ? {
+              truncation_message:
+                "Response truncated. Use a lower limit, narrower filters, or the returned cursor.",
+            }
+          : {}),
+      };
+      return responseFor(
+        output,
+        args.response_format,
+        listingsMarkdown(args.query, bounded.items, output.has_more),
+      );
+    } catch (error) {
+      return toolErrorResponse(
+        "facebook_marketplace_search_listings",
+        args,
+        error,
+        "Unable to search Marketplace",
+      );
+    }
+  };
+}
 
-      const parts = [
+export function createGetListingHandler(service: MarketplaceService) {
+  return async (args: z.infer<typeof getListingInput>) => {
+    try {
+      const listing = await service.getListingDetail(args.listing_id);
+      const description = truncateText(listing.description);
+      const output = {
+        listing: {
+          ...listingOutput(listing),
+          description: description.text,
+          images: listing.images,
+          condition: listing.condition,
+          seller: {
+            name: listing.seller.name,
+            profile_url: listing.seller.profileUrl ?? null,
+          },
+        },
+        truncated: description.truncated,
+        ...(description.truncated
+          ? {
+              truncation_message:
+                "Description truncated; fetch the listing directly for its full text.",
+            }
+          : {}),
+      };
+      const markdown = [
         `# ${listing.title}`,
         "",
         `**Price:** ${listing.price}`,
         listing.condition ? `**Condition:** ${listing.condition}` : null,
         `**Location:** ${listing.location}`,
-        listing.isPending ? "**Status:** ⏳ Pending" : null,
-        "",
-        listing.description
-          ? `## Description\n${listing.description}`
-          : null,
-        "",
-        `**Seller:** ${listing.seller.name}`,
+        listing.isPending ? "**Status:** Pending" : null,
+        listing.description ? `\n## Description\n${description.text}` : null,
+        `\n**Seller:** ${listing.seller.name}`,
         listing.seller.profileUrl
           ? `**Profile:** ${listing.seller.profileUrl}`
           : null,
-        "",
-        listing.images.length > 0
-          ? `**Images:** ${listing.images.length} photo(s)\n${listing.images.map((u, i) => `  ${i + 1}. ${u}`).join("\n")}`
+        listing.images.length
+          ? `\n**Images:** ${listing.images.length} photo(s)\n${listing.images.map((url, index) => `${index + 1}. ${url}`).join("\n")}`
           : null,
-        "",
-        `🔗 ${listing.url}`,
+        `\n🔗 ${listing.url}`,
       ]
         .filter(Boolean)
         .join("\n");
-
-      return {
-        content: [{ type: "text" as const, text: parts }],
-      };
+      return responseFor(output, args.response_format, markdown);
     } catch (error) {
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Error fetching listing: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return toolErrorResponse(
+        "facebook_marketplace_get_listing",
+        args,
+        error,
+        "Unable to fetch Marketplace listing",
+      );
     }
   };
 }

--- a/src/tools/listing.ts
+++ b/src/tools/listing.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import type { z } from "zod/v4";
 import { getListingInput, searchListingsInput } from "../mcp/contracts.js";
 import {
   responseFor,

--- a/src/tools/listing.ts
+++ b/src/tools/listing.ts
@@ -20,6 +20,9 @@ export function createSearchListingsHandler(service: MarketplaceService) {
         minPrice: args.min_price,
         maxPrice: args.max_price,
         category: args.category,
+        sortBy: args.sort_by,
+        deliveryMethod: args.delivery_method,
+        dateListed: args.date_listed,
         limit: args.limit,
         cursor: args.cursor,
       });

--- a/src/tools/location.ts
+++ b/src/tools/location.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import type { z } from "zod/v4";
 import { searchLocationsInput } from "../mcp/contracts.js";
 import { responseFor, takeWithinCharacterLimit } from "../mcp/response.js";
 import type { MarketplaceService } from "../mcp/types.js";

--- a/src/tools/location.ts
+++ b/src/tools/location.ts
@@ -1,53 +1,39 @@
-import { z } from "zod";
-import type { FacebookClient } from "../facebook/client.js";
+import type { z } from "zod";
+import { searchLocationsInput } from "../mcp/contracts.js";
+import { responseFor, takeWithinCharacterLimit } from "../mcp/response.js";
+import type { MarketplaceService } from "../mcp/types.js";
+import { toolErrorResponse } from "../utils/diagnostics.js";
 
-export const searchLocationSchema = {
-  query: z
-    .string()
-    .describe(
-      "Location search query (e.g. 'Dedham MA', 'Boston', 'Brooklyn NY')"
-    ),
-};
-
-export function createLocationHandler(client: FacebookClient) {
-  return async (args: { query: string }) => {
+export function createSearchLocationsHandler(service: MarketplaceService) {
+  return async (args: z.infer<typeof searchLocationsInput>) => {
     try {
-      const results = await client.searchLocation(args.query);
-
-      if (results.length === 0) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `No locations found for "${args.query}". Try a city or town name with state abbreviation.`,
-            },
-          ],
-        };
-      }
-
-      const lines = results.map(
-        (r, i) =>
-          `${i + 1}. **${r.name}** — lat: ${r.latitude}, lng: ${r.longitude}`
+      const bounded = takeWithinCharacterLimit(
+        await service.searchLocation(args.query),
+        (location) => JSON.stringify(location),
       );
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Found ${results.length} location(s) for "${args.query}":\n\n${lines.join("\n")}\n\nUse these coordinates with search_listings.`,
-          },
-        ],
+      const output = {
+        query: args.query,
+        count: bounded.items.length,
+        locations: bounded.items,
+        truncated: bounded.truncated,
+        ...(bounded.truncated
+          ? {
+              truncation_message:
+                "Response truncated. Use a more specific location query.",
+            }
+          : {}),
       };
+      const markdown = bounded.items.length
+        ? `# Locations for "${args.query}"\n\n${bounded.items.map((location, index) => `${index + 1}. **${location.name}** — lat: ${location.latitude}, lng: ${location.longitude}`).join("\n")}`
+        : `No locations found for "${args.query}". Try a city, town, or ZIP code.`;
+      return responseFor(output, args.response_format, markdown);
     } catch (error) {
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Error searching locations: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return toolErrorResponse(
+        "facebook_marketplace_search_locations",
+        args,
+        error,
+        "Unable to search Marketplace locations",
+      );
     }
   };
 }

--- a/src/tools/monitor.ts
+++ b/src/tools/monitor.ts
@@ -1,50 +1,23 @@
-import { z } from "zod";
-import type { FacebookClient } from "../facebook/client.js";
+import type { z } from "zod";
+import { responseFor, takeWithinCharacterLimit } from "../mcp/response.js";
+import type {
+  MarketplaceService,
+  MonitorStore,
+  SavedMonitor,
+} from "../mcp/types.js";
+import { toolErrorResponse } from "../utils/diagnostics.js";
+import { listingOutput, monitorOutput } from "./shared.js";
 import {
-  addMonitor,
-  loadMonitors,
-  getMonitor,
-  updateMonitorSeenIds,
-  deleteMonitor,
-} from "../storage/monitors.js";
+  checkMonitorsInput,
+  createMonitorInput,
+  deleteMonitorInput,
+  listMonitorsInput,
+} from "../mcp/contracts.js";
 
-export const monitorSearchSchema = {
-  name: z.string().describe("Name for this saved search monitor"),
-  query: z.string().describe("Search query"),
-  latitude: z.number().describe("Latitude of search center"),
-  longitude: z.number().describe("Longitude of search center"),
-  radius_km: z.number().default(50).describe("Search radius in km"),
-  min_price: z.number().optional().describe("Min price filter in dollars"),
-  max_price: z.number().optional().describe("Max price filter in dollars"),
-  category: z.string().optional().describe("Category ID"),
-};
-
-export const checkMonitorsSchema = {
-  monitor_name: z
-    .string()
-    .optional()
-    .describe("Check a specific monitor by name, or omit to check all"),
-};
-
-export const deleteMonitorSchema = {
-  name: z.string().describe("Name of the monitor to delete"),
-};
-
-export const listMonitorsSchema = {};
-
-export function createMonitorSearchHandler() {
-  return async (args: {
-    name: string;
-    query: string;
-    latitude: number;
-    longitude: number;
-    radius_km: number;
-    min_price?: number;
-    max_price?: number;
-    category?: string;
-  }) => {
+export function createCreateMonitorHandler(store: MonitorStore) {
+  return async (args: z.infer<typeof createMonitorInput>) => {
     try {
-      const monitor = addMonitor(args.name, {
+      const monitor = store.add(args.name, {
         query: args.query,
         latitude: args.latitude,
         longitude: args.longitude,
@@ -54,137 +27,146 @@ export function createMonitorSearchHandler() {
         category: args.category,
         limit: 24,
       });
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Monitor "${monitor.name}" saved.\nID: ${monitor.id}\nQuery: "${args.query}" within ${args.radius_km}km\nUse check_monitors to check for new listings.`,
-          },
-        ],
-      };
+      const output = { monitor: monitorOutput(monitor) };
+      return responseFor(
+        output,
+        args.response_format,
+        `# Monitor saved\n\n**${monitor.name}** searches for "${monitor.params.query}" within ${monitor.params.radiusKm} km.`,
+      );
     } catch (error) {
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Error: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return toolErrorResponse(
+        "facebook_marketplace_create_monitor",
+        args,
+        error,
+        "Unable to create monitor",
+      );
     }
   };
 }
 
-export function createCheckMonitorsHandler(client: FacebookClient) {
-  return async (args: { monitor_name?: string }) => {
+export function createCheckMonitorsHandler(
+  service: MarketplaceService,
+  store: MonitorStore,
+) {
+  return async (args: z.infer<typeof checkMonitorsInput>) => {
     try {
       const monitors = args.monitor_name
-        ? [getMonitor(args.monitor_name)].filter(Boolean)
-        : loadMonitors();
-
-      if (monitors.length === 0) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: args.monitor_name
-                ? `Monitor "${args.monitor_name}" not found.`
-                : "No monitors saved. Use monitor_search to create one.",
-            },
-          ],
-        };
-      }
-
-      const results: string[] = [];
-
+        ? [store.get(args.monitor_name)].filter(
+            (monitor): monitor is SavedMonitor => Boolean(monitor),
+          )
+        : store.list();
+      const results: Array<{
+        name: string;
+        found: boolean;
+        new_listings: ReturnType<typeof listingOutput>[];
+      }> = [];
       for (const monitor of monitors) {
-        if (!monitor) continue;
-
-        const searchResult = await client.searchListings(monitor.params);
-        const newListings = searchResult.listings.filter(
-          (l) => !monitor.seenIds.includes(l.id)
+        const search = await service.searchListings(monitor.params);
+        const newListings = search.listings.filter(
+          (listing) => !monitor.seenIds.includes(listing.id),
         );
-
-        if (newListings.length > 0) {
-          updateMonitorSeenIds(
-            monitor.name,
-            newListings.map((l) => l.id)
-          );
-
-          const listingSummary = newListings
-            .map(
-              (l, i) =>
-                `  ${i + 1}. **${l.title}** — ${l.price}\n     📍 ${l.location}\n     🔗 ${l.url}`
-            )
-            .join("\n\n");
-
-          results.push(
-            `### 🔔 ${monitor.name} — ${newListings.length} new listing(s)\n\n${listingSummary}`
-          );
-        } else {
-          updateMonitorSeenIds(monitor.name, []);
-          results.push(`### ${monitor.name} — no new listings`);
-        }
+        store.updateSeenIds(
+          monitor.name,
+          newListings.map((listing) => listing.id),
+        );
+        results.push({
+          name: monitor.name,
+          found: true,
+          new_listings: newListings.map(listingOutput),
+        });
       }
-
-      return {
-        content: [{ type: "text" as const, text: results.join("\n\n---\n\n") }],
+      if (args.monitor_name && results.length === 0)
+        results.push({
+          name: args.monitor_name,
+          found: false,
+          new_listings: [],
+        });
+      const bounded = takeWithinCharacterLimit(results, (result) =>
+        JSON.stringify(result),
+      );
+      const output = {
+        count: bounded.items.length,
+        results: bounded.items,
+        truncated: bounded.truncated,
+        ...(bounded.truncated
+          ? {
+              truncation_message:
+                "Response truncated. Check one monitor at a time.",
+            }
+          : {}),
       };
+      const markdown = output.results.length
+        ? output.results
+            .map((result) =>
+              !result.found
+                ? `## ${result.name}\n\nMonitor not found.`
+                : `## ${result.name}\n\n${result.new_listings.length ? result.new_listings.map((listing) => `- **${listing.title}** — ${listing.price}\n  ${listing.url}`).join("\n") : "No new listings."}`,
+            )
+            .join("\n\n")
+        : "No monitors saved. Create one before checking for new listings.";
+      return responseFor(output, args.response_format, markdown);
     } catch (error) {
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Error checking monitors: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return toolErrorResponse(
+        "facebook_marketplace_check_monitors",
+        args,
+        error,
+        "Unable to check monitors",
+      );
     }
   };
 }
 
-export function createDeleteMonitorHandler() {
-  return async (args: { name: string }) => {
-    const deleted = deleteMonitor(args.name);
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: deleted
-            ? `Monitor "${args.name}" deleted.`
-            : `Monitor "${args.name}" not found.`,
-        },
-      ],
-    };
+export function createDeleteMonitorHandler(store: MonitorStore) {
+  return async (args: z.infer<typeof deleteMonitorInput>) => {
+    try {
+      const output = { name: args.name, deleted: store.delete(args.name) };
+      return responseFor(
+        output,
+        args.response_format,
+        output.deleted
+          ? `Monitor "${args.name}" deleted.`
+          : `Monitor "${args.name}" was not found.`,
+      );
+    } catch (error) {
+      return toolErrorResponse(
+        "facebook_marketplace_delete_monitor",
+        args,
+        error,
+        "Unable to delete monitor",
+      );
+    }
   };
 }
 
-export function createListMonitorsHandler() {
-  return async () => {
-    const monitors = loadMonitors();
-    if (monitors.length === 0) {
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: "No monitors saved. Use monitor_search to create one.",
-          },
-        ],
+export function createListMonitorsHandler(store: MonitorStore) {
+  return async (args: z.infer<typeof listMonitorsInput>) => {
+    try {
+      const bounded = takeWithinCharacterLimit(
+        store.list().map(monitorOutput),
+        (monitor) => JSON.stringify(monitor),
+      );
+      const output = {
+        count: bounded.items.length,
+        monitors: bounded.items,
+        truncated: bounded.truncated,
+        ...(bounded.truncated
+          ? {
+              truncation_message:
+                "Response truncated. Delete inactive monitors or inspect monitor storage locally.",
+            }
+          : {}),
       };
+      const markdown = bounded.items.length
+        ? `# Saved monitors\n\n${bounded.items.map((monitor) => `- **${monitor.name}** — "${monitor.query}" (${monitor.radius_km} km)\n  Seen: ${monitor.seen_count} listings`).join("\n")}`
+        : "No monitors saved.";
+      return responseFor(output, args.response_format, markdown);
+    } catch (error) {
+      return toolErrorResponse(
+        "facebook_marketplace_list_monitors",
+        args,
+        error,
+        "Unable to list monitors",
+      );
     }
-
-    const list = monitors
-      .map(
-        (m) =>
-          `- **${m.name}** — "${m.params.query}" (${m.params.radiusKm}km)\n  Created: ${m.createdAt}${m.lastChecked ? ` | Last checked: ${m.lastChecked}` : ""}\n  Seen: ${m.seenIds.length} listings`
-      )
-      .join("\n\n");
-
-    return {
-      content: [{ type: "text" as const, text: `## Saved Monitors\n\n${list}` }],
-    };
   };
 }

--- a/src/tools/monitor.ts
+++ b/src/tools/monitor.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import type { z } from "zod/v4";
 import { responseFor, takeWithinCharacterLimit } from "../mcp/response.js";
 import type {
   MarketplaceService,

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -1,0 +1,45 @@
+import type { MarketplaceListing, SavedMonitor } from "../mcp/types.js";
+
+export function listingOutput(listing: MarketplaceListing) {
+  return {
+    id: listing.id,
+    title: listing.title,
+    price: listing.price,
+    location: listing.location,
+    image_url: listing.imageUrl,
+    seller_name: listing.sellerName,
+    posted_date: listing.postedDate,
+    url: listing.url,
+    is_pending: listing.isPending,
+  };
+}
+
+export function monitorOutput(monitor: SavedMonitor) {
+  return {
+    id: monitor.id,
+    name: monitor.name,
+    query: monitor.params.query,
+    latitude: monitor.params.latitude,
+    longitude: monitor.params.longitude,
+    radius_km: monitor.params.radiusKm,
+    min_price: monitor.params.minPrice,
+    max_price: monitor.params.maxPrice,
+    category: monitor.params.category,
+    created_at: monitor.createdAt,
+    last_checked: monitor.lastChecked,
+    seen_count: monitor.seenIds.length,
+  };
+}
+
+export function listingsMarkdown(
+  query: string,
+  listings: ReturnType<typeof listingOutput>[],
+  hasMore: boolean,
+) {
+  if (listings.length === 0) return `No listings found for "${query}".`;
+  const rows = listings.map(
+    (listing, index) =>
+      `${index + 1}. **${listing.title}** — ${listing.price}\n   📍 ${listing.location} | 👤 ${listing.seller_name}${listing.is_pending ? " ⏳ PENDING" : ""}\n   🔗 ${listing.url}`,
+  );
+  return `# Marketplace listings for "${query}"\n\n${rows.join("\n\n")}${hasMore ? "\n\n_More results are available with the returned cursor._" : ""}`;
+}

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -104,6 +104,31 @@ function diagnosticLogPath(): string {
   return resolve(process.env.MCP_ERROR_LOG_PATH ?? ".local/mcp-errors.jsonl");
 }
 
+export async function recordGraphqlWarning(
+  request: FacebookRequestContext,
+  summary: { errorCount: number; codes: number[] },
+): Promise<void> {
+  // Only accept a summary: provider messages and raw payloads must not be logged.
+  const record = {
+    timestamp: new Date().toISOString(),
+    correlationId: randomUUID(),
+    level: "warning",
+    event: "graphql-provider-errors",
+    request,
+    errorCount: summary.errorCount,
+    codes: [...new Set(summary.codes.filter(Number.isFinite))],
+  };
+  try {
+    const logPath = diagnosticLogPath();
+    await mkdir(dirname(logPath), { recursive: true });
+    await appendFile(logPath, `${JSON.stringify(record)}\n`, "utf8");
+  } catch {
+    process.stderr.write(
+      "[facebook-marketplace-mcp] could not record GraphQL warning\n",
+    );
+  }
+}
+
 export async function recordToolFailure(
   tool: string,
   input: unknown,

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -1,0 +1,162 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+
+const REDACTED = "[REDACTED]";
+const MAX_STRING_LENGTH = 500;
+const MAX_DEPTH = 4;
+
+export type FacebookRequestContext = {
+  operation: "marketplace-bootstrap" | "graphql" | "listing-page";
+  method: "GET" | "POST";
+  path: string;
+  status?: number;
+  docId?: string;
+  responseBytes?: number;
+};
+
+export class MarketplaceRequestError extends Error {
+  readonly request: FacebookRequestContext;
+
+  constructor(
+    message: string,
+    request: FacebookRequestContext,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "MarketplaceRequestError";
+    this.request = request;
+  }
+}
+
+export type ToolFailureRecord = {
+  timestamp: string;
+  correlationId: string;
+  tool: string;
+  input: unknown;
+  error: {
+    name: string;
+    message: string;
+    request?: FacebookRequestContext;
+  };
+};
+
+function isSensitiveKey(key: string): boolean {
+  return /(authorization|cookie|csrf|dtsg|lsd|jazoest|token|secret|password|session|header|body|html|response)/i.test(
+    key,
+  );
+}
+
+function sanitizeString(value: string): string {
+  const truncated = value.slice(0, MAX_STRING_LENGTH);
+  if (/(?:<!doctype|<html|<body|<script|^\s*[\[{]\s*\")/i.test(truncated)) {
+    return "[REDACTED RAW CONTENT]";
+  }
+  return truncated
+    .replace(
+      /\b(authorization|cookie|csrf|token|secret|password)\s*([:=])\s*[^\s,;]+/gi,
+      (_match, key: string, separator: string) =>
+        `${key}${separator}${REDACTED}`,
+    )
+    .replace(
+      /\b(?:c_user|xs|datr|fr|sb)=[^;\s]+/gi,
+      (match) => `${match.split("=")[0]}=${REDACTED}`,
+    );
+}
+
+function sanitizeValue(value: unknown, key?: string, depth = 0): unknown {
+  if (key && isSensitiveKey(key)) return REDACTED;
+  if (depth >= MAX_DEPTH) return "[TRUNCATED]";
+  if (typeof value === "string") return sanitizeString(value);
+  if (typeof value === "number" || typeof value === "boolean" || value === null)
+    return value;
+  if (Array.isArray(value))
+    return value
+      .slice(0, 50)
+      .map((item) => sanitizeValue(item, undefined, depth + 1));
+  if (typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      result[childKey] = sanitizeValue(childValue, childKey, depth + 1);
+    }
+    return result;
+  }
+  return String(value);
+}
+
+function normalizeError(error: unknown): ToolFailureRecord["error"] {
+  if (error instanceof MarketplaceRequestError) {
+    return {
+      name: error.name,
+      message: sanitizeString(error.message),
+      request: error.request,
+    };
+  }
+
+  if (error instanceof Error) {
+    return { name: error.name, message: sanitizeString(error.message) };
+  }
+
+  return { name: "UnknownError", message: sanitizeString(String(error)) };
+}
+
+function diagnosticLogPath(): string {
+  return resolve(process.env.MCP_ERROR_LOG_PATH ?? ".local/mcp-errors.jsonl");
+}
+
+export async function recordToolFailure(
+  tool: string,
+  input: unknown,
+  error: unknown,
+  options: { logPath?: string } = {},
+): Promise<string> {
+  const correlationId = randomUUID();
+  const record: ToolFailureRecord = {
+    timestamp: new Date().toISOString(),
+    correlationId,
+    tool,
+    input: sanitizeValue(input),
+    error: normalizeError(error),
+  };
+  const logPath = options.logPath
+    ? resolve(options.logPath)
+    : diagnosticLogPath();
+
+  try {
+    await mkdir(dirname(logPath), { recursive: true });
+    await appendFile(logPath, `${JSON.stringify(record)}\n`, "utf8");
+  } catch (logError) {
+    const message =
+      logError instanceof Error
+        ? sanitizeString(logError.message)
+        : "unknown error";
+    process.stderr.write(
+      `[facebook-marketplace-mcp] could not record diagnostic: ${message}\n`,
+    );
+  }
+
+  return correlationId;
+}
+
+export async function toolErrorResponse(
+  tool: string,
+  input: unknown,
+  error: unknown,
+  prefix = "Error",
+) {
+  const correlationId = await recordToolFailure(tool, input, error);
+  const message =
+    error instanceof Error
+      ? sanitizeString(error.message)
+      : sanitizeString(String(error));
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `${prefix}: ${message} (diagnostic ID: ${correlationId})`,
+      },
+    ],
+    isError: true,
+  };
+}

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,16 +1,24 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
   loadFacebookCookies,
   loadFacebookCookiesFromFile,
+  saveFacebookCookiesToFile,
 } from "../src/facebook/auth.js";
 
 function withSessionFile(
   content: string,
-  run: (filePath: string) => void
+  run: (filePath: string) => void,
 ): void {
   const directory = mkdtempSync(join(tmpdir(), "facebook-session-test-"));
   const filePath = join(directory, "session.json");
@@ -52,14 +60,14 @@ test("loads a Chrome-style JSON cookie file without invoking Chrome", () => {
 
     assert.deepEqual(
       cookies.map((cookie) => cookie.name),
-      ["c_user", "xs"]
+      ["c_user", "xs"],
     );
     assert.equal(cookies[0].host, ".facebook.com");
     assert.equal(cookies[0].httpOnly, true);
   });
 });
 
-test("falls back to Chrome when the configured cookie file is invalid", () => {
+test("falls back to Chrome, normalizes, and persists an invalid session file", () => {
   withSessionFile("not json", (filePath) => {
     const cookies = loadFacebookCookies({
       sessionFile: filePath,
@@ -77,12 +85,63 @@ test("falls back to Chrome when the configured cookie file is invalid", () => {
             secure: true,
             httpOnly: true,
           },
+          {
+            host: ".facebook.com",
+            name: "xs",
+            value: "fallback-session",
+            path: "/",
+            expires: futureExpiry,
+            secure: true,
+            httpOnly: true,
+          },
         ];
       },
     });
 
     assert.equal(cookies[0].value, "fallback-user");
+    const snapshot = JSON.parse(readFileSync(filePath, "utf8"));
+    assert.equal(snapshot.version, 1);
+    assert.equal(snapshot.cookies[0].domain, ".facebook.com");
+    assert.equal(snapshot.cookies[1].expirationDate, futureExpiry);
+    assert.equal(lstatSync(filePath).mode & 0o777, 0o600);
   });
+});
+
+test("refuses to overwrite a symbolic-link session file", () => {
+  const directory = mkdtempSync(join(tmpdir(), "facebook-session-test-"));
+  const target = join(directory, "target.json");
+  const link = join(directory, "session.json");
+  writeFileSync(target, "keep me", { mode: 0o600 });
+  symlinkSync(target, link);
+  try {
+    assert.throws(
+      () =>
+        saveFacebookCookiesToFile(link, [
+          {
+            host: ".facebook.com",
+            name: "c_user",
+            value: "test-user",
+            path: "/",
+            expires: futureExpiry,
+            secure: true,
+            httpOnly: true,
+          },
+          {
+            host: ".facebook.com",
+            name: "xs",
+            value: "test-session",
+            path: "/",
+            expires: futureExpiry,
+            secure: true,
+            httpOnly: true,
+          },
+        ]),
+      /not a symbolic link/,
+    );
+    assert.equal(readFileSync(target, "utf8"), "keep me");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("rejects files with missing, expired, or non-Facebook session cookies", () => {
@@ -91,9 +150,9 @@ test("rejects files with missing, expired, or non-Facebook session cookies", () 
     (filePath) => {
       assert.throws(
         () => loadFacebookCookiesFromFile(filePath),
-        /no active c_user cookie/
+        /no active c_user cookie/,
       );
-    }
+    },
   );
 
   withSessionFile(
@@ -104,28 +163,31 @@ test("rejects files with missing, expired, or non-Facebook session cookies", () 
     (filePath) => {
       assert.throws(
         () => loadFacebookCookiesFromFile(filePath),
-        /not scoped to facebook\.com/
+        /not scoped to facebook\.com/,
       );
-    }
+    },
   );
 });
 
 test("reports both sources without exposing cookie values when both fail", () => {
-  withSessionFile(JSON.stringify([{ name: "c_user", value: "secret" }]), (filePath) => {
-    assert.throws(
-      () =>
-        loadFacebookCookies({
-          sessionFile: filePath,
-          extractChrome: () => {
-            throw new Error("Keychain unavailable");
-          },
-        }),
-      (error: Error) => {
-        assert.match(error.message, /FACEBOOK_SESSION_FILE/);
-        assert.match(error.message, /Keychain unavailable/);
-        assert.doesNotMatch(error.message, /secret/);
-        return true;
-      }
-    );
-  });
+  withSessionFile(
+    JSON.stringify([{ name: "c_user", value: "secret" }]),
+    (filePath) => {
+      assert.throws(
+        () =>
+          loadFacebookCookies({
+            sessionFile: filePath,
+            extractChrome: () => {
+              throw new Error("Keychain unavailable");
+            },
+          }),
+        (error: Error) => {
+          assert.match(error.message, /FACEBOOK_SESSION_FILE/);
+          assert.match(error.message, /Keychain unavailable/);
+          assert.doesNotMatch(error.message, /secret/);
+          return true;
+        },
+      );
+    },
+  );
 });

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -49,61 +49,11 @@ const validCookies = [
   },
 ];
 
-test("loads a Chrome-style JSON cookie file without invoking Chrome", () => {
-  withSessionFile(JSON.stringify({ cookies: validCookies }), (filePath) => {
-    const cookies = loadFacebookCookies({
-      sessionFile: filePath,
-      extractChrome: () => {
-        throw new Error("Chrome should not be read");
-      },
-    });
-
-    assert.deepEqual(
-      cookies.map((cookie) => cookie.name),
-      ["c_user", "xs"],
-    );
-    assert.equal(cookies[0].host, ".facebook.com");
+test("loads the login session format", () => {
+  withSessionFile(JSON.stringify({ version: 1, userAgent: "Browser/150", cookies: validCookies }), (filePath) => {
+    const cookies = loadFacebookCookies({ sessionFile: filePath });
+    assert.deepEqual(cookies.map(cookie => cookie.name), ["c_user", "xs"]);
     assert.equal(cookies[0].httpOnly, true);
-  });
-});
-
-test("falls back to Chrome, normalizes, and persists an invalid session file", () => {
-  withSessionFile("not json", (filePath) => {
-    const cookies = loadFacebookCookies({
-      sessionFile: filePath,
-      chromeProfile: "Profile 1",
-      extractChrome: (domain, profile) => {
-        assert.equal(domain, "facebook.com");
-        assert.equal(profile, "Profile 1");
-        return [
-          {
-            host: ".facebook.com",
-            name: "c_user",
-            value: "fallback-user",
-            path: "/",
-            expires: 0,
-            secure: true,
-            httpOnly: true,
-          },
-          {
-            host: ".facebook.com",
-            name: "xs",
-            value: "fallback-session",
-            path: "/",
-            expires: futureExpiry,
-            secure: true,
-            httpOnly: true,
-          },
-        ];
-      },
-    });
-
-    assert.equal(cookies[0].value, "fallback-user");
-    const snapshot = JSON.parse(readFileSync(filePath, "utf8"));
-    assert.equal(snapshot.version, 1);
-    assert.equal(snapshot.cookies[0].domain, ".facebook.com");
-    assert.equal(snapshot.cookies[1].expirationDate, futureExpiry);
-    assert.equal(lstatSync(filePath).mode & 0o777, 0o600);
   });
 });
 
@@ -135,7 +85,7 @@ test("refuses to overwrite a symbolic-link session file", () => {
             secure: true,
             httpOnly: true,
           },
-        ]),
+        ], "Browser/150"),
       /not a symbolic link/,
     );
     assert.equal(readFileSync(target, "utf8"), "keep me");
@@ -146,7 +96,7 @@ test("refuses to overwrite a symbolic-link session file", () => {
 
 test("rejects files with missing, expired, or non-Facebook session cookies", () => {
   withSessionFile(
-    JSON.stringify([{ ...validCookies[0], expirationDate: 1 }]),
+    JSON.stringify({ version: 1, userAgent: "Browser/150", cookies: [{ ...validCookies[0], expirationDate: 1 }] }),
     (filePath) => {
       assert.throws(
         () => loadFacebookCookiesFromFile(filePath),
@@ -156,10 +106,10 @@ test("rejects files with missing, expired, or non-Facebook session cookies", () 
   );
 
   withSessionFile(
-    JSON.stringify([
+    JSON.stringify({ version: 1, userAgent: "Browser/150", cookies: [
       { ...validCookies[0], domain: ".example.com" },
       validCookies[1],
-    ]),
+    ] }),
     (filePath) => {
       assert.throws(
         () => loadFacebookCookiesFromFile(filePath),
@@ -169,25 +119,12 @@ test("rejects files with missing, expired, or non-Facebook session cookies", () 
   );
 });
 
-test("reports both sources without exposing cookie values when both fail", () => {
-  withSessionFile(
-    JSON.stringify([{ name: "c_user", value: "secret" }]),
-    (filePath) => {
-      assert.throws(
-        () =>
-          loadFacebookCookies({
-            sessionFile: filePath,
-            extractChrome: () => {
-              throw new Error("Keychain unavailable");
-            },
-          }),
-        (error: Error) => {
-          assert.match(error.message, /FACEBOOK_SESSION_FILE/);
-          assert.match(error.message, /Keychain unavailable/);
-          assert.doesNotMatch(error.message, /secret/);
-          return true;
-        },
-      );
-    },
-  );
+test("reports invalid sessions without exposing cookie values", () => {
+  withSessionFile(JSON.stringify({ version: 1, userAgent: "Browser/150", cookies: [{ name: "c_user", value: "secret" }] }), filePath => {
+    assert.throws(() => loadFacebookCookies({ sessionFile: filePath }), (error: Error) => {
+      assert.match(error.message, /npm run login/);
+      assert.doesNotMatch(error.message, /secret/);
+      return true;
+    });
+  });
 });

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  loadFacebookCookies,
+  loadFacebookCookiesFromFile,
+} from "../src/facebook/auth.js";
+
+function withSessionFile(
+  content: string,
+  run: (filePath: string) => void
+): void {
+  const directory = mkdtempSync(join(tmpdir(), "facebook-session-test-"));
+  const filePath = join(directory, "session.json");
+  writeFileSync(filePath, content, { mode: 0o600 });
+  try {
+    run(filePath);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+const futureExpiry = Math.floor(Date.now() / 1000) + 3600;
+const validCookies = [
+  {
+    name: "c_user",
+    value: "test-user",
+    domain: ".facebook.com",
+    path: "/",
+    expirationDate: futureExpiry,
+    secure: true,
+    httpOnly: true,
+  },
+  {
+    name: "xs",
+    value: "test-session",
+    domain: ".facebook.com",
+    expirationDate: futureExpiry,
+  },
+];
+
+test("loads a Chrome-style JSON cookie file without invoking Chrome", () => {
+  withSessionFile(JSON.stringify({ cookies: validCookies }), (filePath) => {
+    const cookies = loadFacebookCookies({
+      sessionFile: filePath,
+      extractChrome: () => {
+        throw new Error("Chrome should not be read");
+      },
+    });
+
+    assert.deepEqual(
+      cookies.map((cookie) => cookie.name),
+      ["c_user", "xs"]
+    );
+    assert.equal(cookies[0].host, ".facebook.com");
+    assert.equal(cookies[0].httpOnly, true);
+  });
+});
+
+test("falls back to Chrome when the configured cookie file is invalid", () => {
+  withSessionFile("not json", (filePath) => {
+    const cookies = loadFacebookCookies({
+      sessionFile: filePath,
+      chromeProfile: "Profile 1",
+      extractChrome: (domain, profile) => {
+        assert.equal(domain, "facebook.com");
+        assert.equal(profile, "Profile 1");
+        return [
+          {
+            host: ".facebook.com",
+            name: "c_user",
+            value: "fallback-user",
+            path: "/",
+            expires: 0,
+            secure: true,
+            httpOnly: true,
+          },
+        ];
+      },
+    });
+
+    assert.equal(cookies[0].value, "fallback-user");
+  });
+});
+
+test("rejects files with missing, expired, or non-Facebook session cookies", () => {
+  withSessionFile(
+    JSON.stringify([{ ...validCookies[0], expirationDate: 1 }]),
+    (filePath) => {
+      assert.throws(
+        () => loadFacebookCookiesFromFile(filePath),
+        /no active c_user cookie/
+      );
+    }
+  );
+
+  withSessionFile(
+    JSON.stringify([
+      { ...validCookies[0], domain: ".example.com" },
+      validCookies[1],
+    ]),
+    (filePath) => {
+      assert.throws(
+        () => loadFacebookCookiesFromFile(filePath),
+        /not scoped to facebook\.com/
+      );
+    }
+  );
+});
+
+test("reports both sources without exposing cookie values when both fail", () => {
+  withSessionFile(JSON.stringify([{ name: "c_user", value: "secret" }]), (filePath) => {
+    assert.throws(
+      () =>
+        loadFacebookCookies({
+          sessionFile: filePath,
+          extractChrome: () => {
+            throw new Error("Keychain unavailable");
+          },
+        }),
+      (error: Error) => {
+        assert.match(error.message, /FACEBOOK_SESSION_FILE/);
+        assert.match(error.message, /Keychain unavailable/);
+        assert.doesNotMatch(error.message, /secret/);
+        return true;
+      }
+    );
+  });
+});

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { FacebookClient } from "../src/facebook/client.js";
+import { MARKETPLACE_SEARCH_DOC_ID } from "../src/facebook/queries.js";
+import { createSearchListingsHandler } from "../src/tools/listing.js";
+import { MarketplaceRequestError } from "../src/utils/diagnostics.js";
+
+const params = {
+  query: "desk",
+  latitude: 42,
+  longitude: -71,
+  radiusKm: 50,
+  limit: 20,
+};
+const validData = {
+  marketplace_search: {
+    feed_units: {
+      edges: [
+        {
+          node: {
+            listing: { id: "listing-1", marketplace_listing_title: "Desk" },
+          },
+        },
+      ],
+      page_info: { has_next_page: true, end_cursor: "next" },
+    },
+  },
+};
+
+async function withResponse(
+  body: string,
+  run: (
+    client: FacebookClient,
+    logPath: string,
+    directory: string,
+  ) => Promise<void>,
+) {
+  const directory = await mkdtemp(join(tmpdir(), "marketplace-client-test-"));
+  const logPath = join(directory, "mcp-errors.jsonl");
+  const previousFetch = globalThis.fetch;
+  const previousLogPath = process.env.MCP_ERROR_LOG_PATH;
+  process.env.MCP_ERROR_LOG_PATH = logPath;
+  globalThis.fetch = async () => new Response(body, { status: 200 });
+  const client = new FacebookClient();
+  client.ensureSession = async () => ({
+    cookies: [],
+    cookieHeader: "c_user=private-user; xs=private-cookie",
+    userId: "private-user",
+    fbDtsg: "private-token",
+    lsd: "private-lsd",
+    jazoest: "",
+    clientRevision: "1",
+  });
+  try {
+    await run(client, logPath, directory);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousLogPath === undefined) delete process.env.MCP_ERROR_LOG_PATH;
+    else process.env.MCP_ERROR_LOG_PATH = previousLogPath;
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("rejects HTTP 200 error-only responses and malformed GraphQL envelopes", async () => {
+  for (const body of [
+    JSON.stringify({
+      errors: [{ message: "private-provider-message", code: 123 }],
+    }),
+    JSON.stringify({
+      error: 1357004,
+      errorDescription: "private-provider-message",
+    }),
+    JSON.stringify({ errors: [{ code: 123 }], data: null }),
+    JSON.stringify({ data: null }),
+    JSON.stringify({ data: [] }),
+    JSON.stringify({ data: "invalid" }),
+    JSON.stringify({}),
+    "null",
+    "[]",
+    '"invalid"',
+    "42",
+    "not JSON",
+    '{"data":',
+    '<html>{"data":{}}</html>',
+  ]) {
+    await withResponse(body, async (client) => {
+      await assert.rejects(client.searchListings(params), (error: unknown) => {
+        assert.ok(error instanceof MarketplaceRequestError);
+        assert.equal(error.request.operation, "graphql");
+        assert.equal(error.request.docId, MARKETPLACE_SEARCH_DOC_ID);
+        assert.equal(error.request.status, 200);
+        assert.equal(error.request.responseBytes, Buffer.byteLength(body));
+        assert.equal(error.message.includes("private-provider-message"), false);
+        return true;
+      });
+    });
+  }
+});
+
+test("accepts valid JSON and Facebook's anti-JSONP prefix without logging warnings", async () => {
+  for (const prefix of ["", "for (;;);", "  for(;;);\n"]) {
+    await withResponse(
+      prefix + JSON.stringify({ data: validData, errors: [], error: 0 }),
+      async (client, logPath) => {
+        const result = await client.searchListings(params);
+        assert.equal(result.listings[0].id, "listing-1");
+        assert.equal(result.hasNextPage, true);
+        await assert.rejects(readFile(logPath), { code: "ENOENT" });
+      },
+    );
+  }
+});
+
+test("logs only safe summaries of provider errors while retaining partial listing data", async () => {
+  const body = JSON.stringify({
+    data: validData,
+    errors: [
+      {
+        message: "private-provider-message",
+        code: 123,
+        extensions: { code: 456, token: "private-extension" },
+      },
+      { message: "private-message-two", code: "private-code", error_code: 789 },
+    ],
+    error: 1357004,
+    errorDescription: "private-top-level-description",
+  });
+  await withResponse(body, async (client, logPath) => {
+    const result = await client.searchListings(params);
+    assert.equal(result.listings[0].id, "listing-1");
+    assert.equal(result.endCursor, "next");
+    const text = await readFile(logPath, "utf8");
+    const lines = text.trim().split("\n");
+    assert.equal(lines.length, 1);
+    const warning = JSON.parse(lines[0]);
+    assert.equal(warning.level, "warning");
+    assert.equal(warning.event, "graphql-provider-errors");
+    assert.equal(warning.errorCount, 3);
+    assert.deepEqual(warning.codes, [123, 456, 789, 1357004]);
+    assert.deepEqual(warning.request, {
+      operation: "graphql",
+      method: "POST",
+      path: "/api/graphql/",
+      docId: MARKETPLACE_SEARCH_DOC_ID,
+      status: 200,
+      responseBytes: Buffer.byteLength(body),
+    });
+    assert.equal(text.includes("private-"), false);
+    assert.equal(text.includes("listing-1"), false);
+    assert.equal(text.includes("Desk"), false);
+  });
+});
+
+test("supports object-shaped provider errors and excludes nonnumeric codes", async () => {
+  await withResponse(
+    JSON.stringify({
+      data: validData,
+      errors: { code: "private-code", message: "private-message" },
+      error: { code: 123, error_code: 123 },
+    }),
+    async (client, logPath) => {
+      assert.equal((await client.searchListings(params)).listings.length, 1);
+      const warning = JSON.parse(await readFile(logPath, "utf8"));
+      assert.equal(warning.errorCount, 2);
+      assert.deepEqual(warning.codes, [123]);
+    },
+  );
+});
+
+test("rejects missing or malformed search connections with GraphQL request context", async () => {
+  for (const data of [
+    {},
+    { marketplace_search: { feed_units: {} } },
+    { marketplace_search: { feed_units: { edges: null } } },
+    { marketplace_search: { feed_units: { edges: [{ node: null }] } } },
+  ]) {
+    await withResponse(
+      JSON.stringify({ data, errors: [{ code: 123 }] }),
+      async (client, logPath) => {
+        await assert.rejects(
+          client.searchListings(params),
+          (error: unknown) => {
+            assert.ok(error instanceof MarketplaceRequestError);
+            assert.equal(error.request.docId, MARKETPLACE_SEARCH_DOC_ID);
+            assert.equal(error.request.operation, "graphql");
+            assert.ok(error.cause instanceof Error);
+            return true;
+          },
+        );
+        assert.equal(
+          JSON.parse(await readFile(logPath, "utf8")).level,
+          "warning",
+        );
+      },
+    );
+  }
+});
+
+test("valid empty partial searches remain successful", async () => {
+  await withResponse(
+    JSON.stringify({
+      data: { marketplace_search: { feed_units: { edges: [] } } },
+      errors: [{ code: 123 }],
+    }),
+    async (client, logPath) => {
+      assert.deepEqual(await client.searchListings(params), {
+        listings: [],
+        hasNextPage: false,
+        endCursor: null,
+      });
+      assert.equal(JSON.parse(await readFile(logPath, "utf8")).errorCount, 1);
+    },
+  );
+});
+
+test("warning log failures do not discard usable partial data", async () => {
+  await withResponse(
+    JSON.stringify({ data: validData, errors: [{ code: 123 }] }),
+    async (client, _logPath, directory) => {
+      // Appending to a directory fails on every platform without permission assumptions.
+      process.env.MCP_ERROR_LOG_PATH = directory;
+      assert.equal(
+        (await client.searchListings(params)).listings[0].id,
+        "listing-1",
+      );
+    },
+  );
+});
+
+test("MCP reports parser failures with a diagnostic ID and preserves partial successes", async () => {
+  for (const data of [{}, validData]) {
+    await withResponse(
+      JSON.stringify({
+        data,
+        errors: [{ message: "private-provider-message", code: 123 }],
+      }),
+      async (client, logPath) => {
+        const result = await createSearchListingsHandler(client)({
+          query: "desk",
+          latitude: 42,
+          longitude: -71,
+          radius_km: 50,
+          limit: 20,
+          sort_by: "suggested",
+          delivery_method: "all",
+          date_listed: "all",
+          response_format: "json",
+        });
+        const text = await readFile(logPath, "utf8");
+        assert.equal(text.includes("private-"), false);
+        const records = text
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        if (data === validData) {
+          assert.ok(!("isError" in result) || !result.isError);
+          assert.equal(records.length, 1);
+        } else {
+          assert.ok("isError" in result && result.isError);
+          assert.match(result.content[0].text, /diagnostic ID:/);
+          assert.equal(records.length, 2);
+          const failure = records[1];
+          assert.ok(result.content[0].text.includes(failure.correlationId));
+          assert.equal(failure.error.request.docId, MARKETPLACE_SEARCH_DOC_ID);
+        }
+      },
+    );
+  }
+});

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  MarketplaceRequestError,
+  recordToolFailure,
+  toolErrorResponse,
+  type ToolFailureRecord,
+} from "../src/utils/diagnostics.js";
+import { createSearchListingsHandler } from "../src/mcp/tools/listings.js";
+import type { MarketplaceService } from "../src/mcp/types.js";
+
+async function withDiagnosticFile(run: (logPath: string) => Promise<void>) {
+  const directory = await mkdtemp(
+    join(tmpdir(), "marketplace-diagnostics-test-"),
+  );
+  try {
+    await run(join(directory, "nested", "mcp-errors.jsonl"));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("records sanitized tool failures with Facebook request context", async () => {
+  await withDiagnosticFile(async (logPath) => {
+    const correlationId = await recordToolFailure(
+      "facebook_marketplace_search_listings",
+      {
+        query: "desk",
+        Cookie: "c_user=private-user; xs=private-session",
+        nested: {
+          authorization: "Bearer private-token",
+          requestBody: "raw body",
+        },
+      },
+      new MarketplaceRequestError("GraphQL request failed: 500", {
+        operation: "graphql",
+        method: "POST",
+        path: "/api/graphql/",
+        docId: "123",
+        status: 500,
+      }),
+      { logPath },
+    );
+
+    const [line] = (await readFile(logPath, "utf8")).trim().split("\n");
+    const record = JSON.parse(line) as ToolFailureRecord;
+
+    assert.equal(record.correlationId, correlationId);
+    assert.equal(record.tool, "facebook_marketplace_search_listings");
+    assert.deepEqual(record.error.request, {
+      operation: "graphql",
+      method: "POST",
+      path: "/api/graphql/",
+      docId: "123",
+      status: 500,
+    });
+    assert.equal(JSON.stringify(record).includes("private-user"), false);
+    assert.equal(JSON.stringify(record).includes("private-session"), false);
+    assert.equal(JSON.stringify(record).includes("private-token"), false);
+    assert.equal(JSON.stringify(record).includes("raw body"), false);
+  });
+});
+
+test("keeps raw response text out of the log and exposes a correlation ID", async () => {
+  await withDiagnosticFile(async (logPath) => {
+    const previousPath = process.env.MCP_ERROR_LOG_PATH;
+    process.env.MCP_ERROR_LOG_PATH = logPath;
+    try {
+      const response = await toolErrorResponse(
+        "facebook_marketplace_search_locations",
+        { query: "Boston" },
+        new Error("<html><body>c_user=private-cookie</body></html>"),
+        "Error searching locations",
+      );
+      const text = response.content[0].text;
+      const diagnosticId = text.match(/diagnostic ID: ([^)]+)/)?.[1];
+      const log = await readFile(logPath, "utf8");
+
+      assert.match(text, /Error searching locations/);
+      assert.ok(diagnosticId);
+      assert.equal(log.includes("private-cookie"), false);
+      assert.match(log, /\[REDACTED RAW CONTENT\]/);
+    } finally {
+      if (previousPath === undefined) delete process.env.MCP_ERROR_LOG_PATH;
+      else process.env.MCP_ERROR_LOG_PATH = previousPath;
+    }
+  });
+});
+
+test("tool handlers preserve MCP errors while recording a correlation ID", async () => {
+  await withDiagnosticFile(async (logPath) => {
+    const previousPath = process.env.MCP_ERROR_LOG_PATH;
+    process.env.MCP_ERROR_LOG_PATH = logPath;
+    try {
+      const client: MarketplaceService = {
+        searchListings: async () => {
+          throw new MarketplaceRequestError("GraphQL request failed: 429", {
+            operation: "graphql",
+            method: "POST",
+            path: "/api/graphql/",
+            docId: "123",
+            status: 429,
+          });
+        },
+        getListingDetail: async () => {
+          throw new Error("not used");
+        },
+        searchLocation: async () => [],
+      };
+      const result = await createSearchListingsHandler(client)({
+        query: "desk",
+        latitude: 42.36,
+        longitude: -71.06,
+        radius_km: 50,
+        limit: 20,
+        response_format: "markdown",
+      });
+
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /diagnostic ID: [^)]+/);
+      const [line] = (await readFile(logPath, "utf8")).trim().split("\n");
+      assert.equal(
+        (JSON.parse(line) as ToolFailureRecord).tool,
+        "facebook_marketplace_search_listings",
+      );
+    } finally {
+      if (previousPath === undefined) delete process.env.MCP_ERROR_LOG_PATH;
+      else process.env.MCP_ERROR_LOG_PATH = previousPath;
+    }
+  });
+});

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -9,7 +9,7 @@ import {
   toolErrorResponse,
   type ToolFailureRecord,
 } from "../src/utils/diagnostics.js";
-import { createSearchListingsHandler } from "../src/mcp/tools/listings.js";
+import { createSearchListingsHandler } from "../src/tools/listing.js";
 import type { MarketplaceService } from "../src/mcp/types.js";
 
 async function withDiagnosticFile(run: (logPath: string) => Promise<void>) {

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { loadFacebookCookiesFromFile } from "../src/facebook/auth.js";
+import { loadFacebookCookiesFromFile, loadFacebookSessionFromFile } from "../src/facebook/auth.js";
 import {
   normalizeFacebookLoginCookies,
   runFacebookLogin,
@@ -58,6 +58,7 @@ test("saves cookies only after a healthy Marketplace validation", async () => {
   const sessionFile = join(directory, "session.json");
   let closeCalls = 0;
   const page = {
+    async evaluate() { return "TestBrowser/150.0"; },
     async goto() {
       return {
         ok: () => true,
@@ -82,6 +83,7 @@ test("saves cookies only after a healthy Marketplace validation", async () => {
       writeOutput: () => undefined,
     });
 
+    assert.equal(loadFacebookSessionFromFile(sessionFile).userAgent, "TestBrowser/150.0");
     assert.equal(closeCalls, 1);
     assert.deepEqual(
       loadFacebookCookiesFromFile(sessionFile).map((cookie) => cookie.name),
@@ -98,6 +100,7 @@ test("does not save cookies after an unhealthy Marketplace response", async () =
   const sessionFile = join(directory, "session.json");
   let closeCalls = 0;
   const page = {
+    async evaluate() { return "TestBrowser/150.0"; },
     async goto() {
       return {
         ok: () => true,

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { loadFacebookCookiesFromFile } from "../src/facebook/auth.js";
+import {
+  normalizeFacebookLoginCookies,
+  runFacebookLogin,
+} from "../src/facebook/login.js";
+
+const futureExpiry = Math.floor(Date.now() / 1000) + 3600;
+
+function loginCookies() {
+  return [
+    {
+      domain: ".facebook.com",
+      name: "c_user",
+      value: "test-user",
+      path: "/",
+      expires: futureExpiry,
+      secure: true,
+      httpOnly: true,
+    },
+    {
+      domain: ".facebook.com",
+      name: "xs",
+      value: "test-session",
+      path: "/",
+      expires: -1,
+      secure: true,
+      httpOnly: true,
+    },
+  ];
+}
+
+test("normalizes browser session-cookie expiry and ignores non-Facebook cookies", () => {
+  const cookies = normalizeFacebookLoginCookies([
+    ...loginCookies(),
+    {
+      domain: ".example.com",
+      name: "unrelated",
+      value: "ignored",
+      path: "/",
+      expires: futureExpiry,
+      secure: true,
+      httpOnly: true,
+    },
+  ]);
+
+  assert.equal(cookies.length, 2);
+  assert.equal(cookies[1].expires, 0);
+});
+
+test("saves cookies only after a healthy Marketplace validation", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "facebook-login-test-"));
+  const profileDirectory = join(directory, "profile");
+  const sessionFile = join(directory, "session.json");
+  let closeCalls = 0;
+  const page = {
+    async goto() {
+      return {
+        ok: () => true,
+        url: () => "https://www.facebook.com/marketplace/",
+      };
+    },
+  };
+
+  try {
+    await runFacebookLogin({
+      loginProfileDirectory: profileDirectory,
+      sessionFile,
+      launch: async () => ({
+        pages: () => [page],
+        newPage: async () => page,
+        cookies: async () => loginCookies(),
+        close: async () => {
+          closeCalls += 1;
+        },
+      }),
+      waitForConfirmation: async () => undefined,
+      writeOutput: () => undefined,
+    });
+
+    assert.equal(closeCalls, 1);
+    assert.deepEqual(
+      loadFacebookCookiesFromFile(sessionFile).map((cookie) => cookie.name),
+      ["c_user", "xs"],
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("does not save cookies after an unhealthy Marketplace response", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "facebook-login-test-"));
+  const profileDirectory = join(directory, "profile");
+  const sessionFile = join(directory, "session.json");
+  let closeCalls = 0;
+  const page = {
+    async goto() {
+      return {
+        ok: () => true,
+        url: () => "https://www.facebook.com/checkpoint/",
+      };
+    },
+  };
+
+  try {
+    await assert.rejects(
+      () =>
+        runFacebookLogin({
+          loginProfileDirectory: profileDirectory,
+          sessionFile,
+          launch: async () => ({
+            pages: () => [page],
+            newPage: async () => page,
+            cookies: async () => loginCookies(),
+            close: async () => {
+              closeCalls += 1;
+            },
+          }),
+          waitForConfirmation: async () => undefined,
+          writeOutput: () => undefined,
+        }),
+      /Marketplace is not authenticated/,
+    );
+
+    assert.equal(closeCalls, 1);
+    assert.equal(existsSync(sessionFile), false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/test/mcp-contract.test.ts
+++ b/test/mcp-contract.test.ts
@@ -2,14 +2,34 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createMarketplaceServer } from "../src/mcp/server.js";
-import type { MarketplaceService, MonitorStore } from "../src/mcp/types.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { fileURLToPath } from "node:url";
+import {
+  searchListingsInput,
+  searchListingsOutput,
+} from "../src/mcp/contracts.js";
+import { createSearchListingsHandler } from "../src/tools/listing.js";
+import type { MarketplaceService } from "../src/mcp/types.js";
 
 const service: MarketplaceService = {
   async searchListings() {
     return {
-      listings: [{ id: "listing-1", title: "Desk chair", price: "$35", location: "Boston, MA", imageUrl: "https://image.example/chair", sellerName: "Ada", postedDate: "today", url: "https://www.facebook.com/marketplace/item/listing-1/", isPending: false }],
-      hasNextPage: true, endCursor: "cursor-2",
+      listings: [
+        {
+          id: "listing-1",
+          title: "Desk chair",
+          price: "$35",
+          location: "Boston, MA",
+          imageUrl: "https://image.example/chair",
+          sellerName: "Ada",
+          postedDate: "today",
+          url: "https://www.facebook.com/marketplace/item/listing-1/",
+          isPending: false,
+        },
+      ],
+      hasNextPage: true,
+      endCursor: "cursor-2",
     };
   },
   async getListingDetail() {
@@ -20,19 +40,37 @@ const service: MarketplaceService = {
   },
 };
 
-function monitorStore(): MonitorStore {
-  return {
-    add(name, params) {
-      return { id: "monitor-1", name, params, seenIds: [], createdAt: "2026-01-01T00:00:00.000Z", lastChecked: null };
-    },
-    list: () => [], get: () => undefined, updateSeenIds: () => undefined, delete: () => false,
-  };
+async function connectedServer() {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["--import", "tsx", "src/index.ts"],
+    cwd: fileURLToPath(new URL("../", import.meta.url)),
+    stderr: "pipe",
+  });
+  const client = new Client({
+    name: "marketplace-contract-test",
+    version: "1.0.0",
+  });
+  await client.connect(transport);
+  return { client, server: transport };
 }
 
-async function connectedServer() {
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  const server = createMarketplaceServer(service, monitorStore());
-  const client = new Client({ name: "marketplace-contract-test", version: "1.0.0" });
+async function connectedSearchServer() {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const server = new McpServer({ name: "search-test", version: "1.0.0" });
+  server.registerTool(
+    "facebook_marketplace_search_listings",
+    {
+      inputSchema: searchListingsInput,
+      outputSchema: searchListingsOutput,
+    },
+    createSearchListingsHandler(service),
+  );
+  const client = new Client({
+    name: "marketplace-contract-test",
+    version: "1.0.0",
+  });
   await server.connect(serverTransport);
   await client.connect(clientTransport);
   return { client, server };
@@ -42,20 +80,68 @@ test("publishes the modern prefixed tool contract with annotations and schemas",
   const { client, server } = await connectedServer();
   try {
     const tools = await client.listTools();
-    assert.equal(client.getServerVersion()?.name, "facebook-marketplace-mcp-server");
-    assert.deepEqual(tools.tools.map((tool) => tool.name), [
-      "facebook_marketplace_search_listings", "facebook_marketplace_get_listing",
-      "facebook_marketplace_search_locations", "facebook_marketplace_create_monitor",
-      "facebook_marketplace_check_monitors", "facebook_marketplace_delete_monitor",
-      "facebook_marketplace_list_monitors",
-    ]);
-    assert.equal(tools.tools.some((tool) => tool.name === "search_listings"), false);
+    assert.equal(client.getServerVersion()?.name, "facebook-marketplace");
+    assert.deepEqual(
+      tools.tools.map((tool) => tool.name),
+      [
+        "facebook_marketplace_search_listings",
+        "facebook_marketplace_get_listing",
+        "facebook_marketplace_search_locations",
+        "facebook_marketplace_create_monitor",
+        "facebook_marketplace_check_monitors",
+        "facebook_marketplace_delete_monitor",
+        "facebook_marketplace_list_monitors",
+      ],
+    );
+    assert.equal(
+      tools.tools.some((tool) => tool.name === "search_listings"),
+      false,
+    );
     for (const tool of tools.tools) {
       assert.ok(tool.description);
       assert.ok(tool.outputSchema);
       assert.ok(tool.annotations);
+      assert.ok(
+        Object.keys(tool.inputSchema.properties ?? {}).length > 0,
+        `${tool.name} must publish input fields`,
+      );
+      assert.equal(tool.inputSchema.additionalProperties, false);
     }
-    const deletion = tools.tools.find((tool) => tool.name === "facebook_marketplace_delete_monitor");
+    const search = tools.tools.find(
+      (tool) => tool.name === "facebook_marketplace_search_listings",
+    )!;
+    assert.deepEqual(Object.keys(search.inputSchema.properties ?? {}), [
+      "query",
+      "latitude",
+      "longitude",
+      "radius_km",
+      "min_price",
+      "max_price",
+      "category",
+      "sort_by",
+      "delivery_method",
+      "date_listed",
+      "limit",
+      "cursor",
+      "response_format",
+    ]);
+    assert.deepEqual(search.inputSchema.required, [
+      "query",
+      "latitude",
+      "longitude",
+    ]);
+    const monitor = tools.tools.find(
+      (tool) => tool.name === "facebook_marketplace_create_monitor",
+    )!;
+    assert.deepEqual(monitor.inputSchema.required, [
+      "name",
+      "query",
+      "latitude",
+      "longitude",
+    ]);
+    const deletion = tools.tools.find(
+      (tool) => tool.name === "facebook_marketplace_delete_monitor",
+    );
     assert.equal(deletion?.annotations?.destructiveHint, true);
   } finally {
     await client.close();
@@ -64,18 +150,42 @@ test("publishes the modern prefixed tool contract with annotations and schemas",
 });
 
 test("returns validated structured content and JSON text for listing search", async () => {
-  const { client, server } = await connectedServer();
+  const { client, server } = await connectedSearchServer();
   try {
     const result = await client.callTool({
       name: "facebook_marketplace_search_listings",
-      arguments: { query: "chair", latitude: 42.36, longitude: -71.06, response_format: "json" },
+      arguments: {
+        query: "chair",
+        latitude: 42.36,
+        longitude: -71.06,
+        response_format: "json",
+      },
     });
     assert.equal(result.isError, undefined);
     assert.deepEqual(result.structuredContent, {
-      query: "chair", count: 1, listings: [{ id: "listing-1", title: "Desk chair", price: "$35", location: "Boston, MA", image_url: "https://image.example/chair", seller_name: "Ada", posted_date: "today", url: "https://www.facebook.com/marketplace/item/listing-1/", is_pending: false }],
-      has_more: true, next_cursor: "cursor-2", truncated: false,
+      query: "chair",
+      count: 1,
+      listings: [
+        {
+          id: "listing-1",
+          title: "Desk chair",
+          price: "$35",
+          location: "Boston, MA",
+          image_url: "https://image.example/chair",
+          seller_name: "Ada",
+          posted_date: "today",
+          url: "https://www.facebook.com/marketplace/item/listing-1/",
+          is_pending: false,
+        },
+      ],
+      has_more: true,
+      next_cursor: "cursor-2",
+      truncated: false,
     });
-    assert.match((result.content[0] as { type: "text"; text: string }).text, /"next_cursor": "cursor-2"/);
+    assert.match(
+      (result.content[0] as { type: "text"; text: string }).text,
+      /"next_cursor": "cursor-2"/,
+    );
   } finally {
     await client.close();
     await server.close();
@@ -85,10 +195,42 @@ test("returns validated structured content and JSON text for listing search", as
 test("rejects unknown properties and invalid price ranges before invoking Marketplace", async () => {
   const { client, server } = await connectedServer();
   try {
-    const extraProperty = await client.callTool({ name: "facebook_marketplace_search_locations", arguments: { query: "Boston", extra: true } });
+    const extraProperty = await client.callTool({
+      name: "facebook_marketplace_search_locations",
+      arguments: { query: "Boston", extra: true },
+    });
     assert.equal(extraProperty.isError, true);
-    const invalidRange = await client.callTool({ name: "facebook_marketplace_search_listings", arguments: { query: "desk", latitude: 42, longitude: -71, min_price: 50, max_price: 10 } });
+    const invalidRange = await client.callTool({
+      name: "facebook_marketplace_search_listings",
+      arguments: {
+        query: "desk",
+        latitude: 42,
+        longitude: -71,
+        min_price: 50,
+        max_price: 10,
+      },
+    });
     assert.equal(invalidRange.isError, true);
+    const invalidMonitorRange = await client.callTool({
+      name: "facebook_marketplace_create_monitor",
+      arguments: {
+        name: "invalid-range-test",
+        query: "desk",
+        latitude: 42,
+        longitude: -71,
+        min_price: 50,
+        max_price: 10,
+      },
+    });
+    assert.equal(invalidMonitorRange.isError, true);
+    assert.match(
+      JSON.stringify(invalidMonitorRange.content),
+      /min_price must not exceed max_price/,
+    );
+    assert.match(
+      JSON.stringify(invalidRange.content),
+      /min_price must not exceed max_price/,
+    );
   } finally {
     await client.close();
     await server.close();

--- a/test/mcp-contract.test.ts
+++ b/test/mcp-contract.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMarketplaceServer } from "../src/mcp/server.js";
+import type { MarketplaceService, MonitorStore } from "../src/mcp/types.js";
+
+const service: MarketplaceService = {
+  async searchListings() {
+    return {
+      listings: [{ id: "listing-1", title: "Desk chair", price: "$35", location: "Boston, MA", imageUrl: "https://image.example/chair", sellerName: "Ada", postedDate: "today", url: "https://www.facebook.com/marketplace/item/listing-1/", isPending: false }],
+      hasNextPage: true, endCursor: "cursor-2",
+    };
+  },
+  async getListingDetail() {
+    throw new Error("not used in this test");
+  },
+  async searchLocation() {
+    return [{ name: "Boston, MA", latitude: 42.36, longitude: -71.06 }];
+  },
+};
+
+function monitorStore(): MonitorStore {
+  return {
+    add(name, params) {
+      return { id: "monitor-1", name, params, seenIds: [], createdAt: "2026-01-01T00:00:00.000Z", lastChecked: null };
+    },
+    list: () => [], get: () => undefined, updateSeenIds: () => undefined, delete: () => false,
+  };
+}
+
+async function connectedServer() {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const server = createMarketplaceServer(service, monitorStore());
+  const client = new Client({ name: "marketplace-contract-test", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return { client, server };
+}
+
+test("publishes the modern prefixed tool contract with annotations and schemas", async () => {
+  const { client, server } = await connectedServer();
+  try {
+    const tools = await client.listTools();
+    assert.equal(client.getServerVersion()?.name, "facebook-marketplace-mcp-server");
+    assert.deepEqual(tools.tools.map((tool) => tool.name), [
+      "facebook_marketplace_search_listings", "facebook_marketplace_get_listing",
+      "facebook_marketplace_search_locations", "facebook_marketplace_create_monitor",
+      "facebook_marketplace_check_monitors", "facebook_marketplace_delete_monitor",
+      "facebook_marketplace_list_monitors",
+    ]);
+    assert.equal(tools.tools.some((tool) => tool.name === "search_listings"), false);
+    for (const tool of tools.tools) {
+      assert.ok(tool.description);
+      assert.ok(tool.outputSchema);
+      assert.ok(tool.annotations);
+    }
+    const deletion = tools.tools.find((tool) => tool.name === "facebook_marketplace_delete_monitor");
+    assert.equal(deletion?.annotations?.destructiveHint, true);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("returns validated structured content and JSON text for listing search", async () => {
+  const { client, server } = await connectedServer();
+  try {
+    const result = await client.callTool({
+      name: "facebook_marketplace_search_listings",
+      arguments: { query: "chair", latitude: 42.36, longitude: -71.06, response_format: "json" },
+    });
+    assert.equal(result.isError, undefined);
+    assert.deepEqual(result.structuredContent, {
+      query: "chair", count: 1, listings: [{ id: "listing-1", title: "Desk chair", price: "$35", location: "Boston, MA", image_url: "https://image.example/chair", seller_name: "Ada", posted_date: "today", url: "https://www.facebook.com/marketplace/item/listing-1/", is_pending: false }],
+      has_more: true, next_cursor: "cursor-2", truncated: false,
+    });
+    assert.match((result.content[0] as { type: "text"; text: string }).text, /"next_cursor": "cursor-2"/);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("rejects unknown properties and invalid price ranges before invoking Marketplace", async () => {
+  const { client, server } = await connectedServer();
+  try {
+    const extraProperty = await client.callTool({ name: "facebook_marketplace_search_locations", arguments: { query: "Boston", extra: true } });
+    assert.equal(extraProperty.isError, true);
+    const invalidRange = await client.callTool({ name: "facebook_marketplace_search_listings", arguments: { query: "desk", latitude: 42, longitude: -71, min_price: 50, max_price: 10 } });
+    assert.equal(invalidRange.isError, true);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parseListingDetailFromPage,
+  parseSearchResponse,
+} from "../src/facebook/parser.js";
+import {
+  buildLocationSearchVariables,
+  buildSearchVariables,
+} from "../src/facebook/queries.js";
+
+test("uses the current Marketplace query shapes", () => {
+  const search = buildSearchVariables({
+    query: "desk",
+    latitude: 42.36,
+    longitude: -71.06,
+    radiusKm: 50,
+    category: "123",
+    limit: 20,
+  }) as {
+    cursor?: string;
+    params: {
+      browse_request_params: { commerce_search_and_rp_category_id: string[] };
+    };
+  };
+  const location = buildLocationSearchVariables("02108", {
+    latitude: 42.36,
+    longitude: -71.06,
+  });
+
+  assert.deepEqual(
+    search.params.browse_request_params.commerce_search_and_rp_category_id,
+    ["123"]
+  );
+  assert.equal(search.cursor, undefined);
+  assert.deepEqual(location.params.page_category, [
+    "CITY",
+    "SUBCITY",
+    "NEIGHBORHOOD",
+    "POSTAL_CODE",
+  ]);
+  assert.deepEqual(location.params.viewer_coordinates, {
+    latitude: 42.36,
+    longitude: -71.06,
+  });
+});
+
+test("parses a Marketplace feed when Facebook moves the listing connection", () => {
+  const result = parseSearchResponse({
+    data: {
+      viewer: {
+        marketplace_feed_stories: {
+          edges: [
+            {
+              node: {
+                id: "listing-1",
+                marketplace_listing_title: "Desk chair",
+                listing_price: { formatted_amount: "$35" },
+                primary_listing_photo: {
+                  image: { uri: "https://image.example/chair" },
+                },
+              },
+            },
+          ],
+          page_info: { has_next_page: true, end_cursor: "next" },
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(result, {
+    listings: [
+      {
+        id: "listing-1",
+        title: "Desk chair",
+        price: "$35",
+        location: "Unknown",
+        imageUrl: "https://image.example/chair",
+        sellerName: "Unknown",
+        postedDate: "",
+        url: "https://www.facebook.com/marketplace/item/listing-1/",
+        isPending: false,
+      },
+    ],
+    hasNextPage: true,
+    endCursor: "next",
+  });
+});
+
+test("uses only the requested listing when page data includes related items", () => {
+  const related = {
+    id: "related-id",
+    marketplace_listing_title: "Wrong item",
+    listing_price: { formatted_amount: "$999" },
+    marketplace_listing_seller: { name: "Wrong seller" },
+  };
+  const requestedTitle = {
+    id: "requested-id",
+    marketplace_listing_title: "Correct item",
+    listing_price: { formatted_amount_zeros_stripped: "$42" },
+    location_text: { text: "Boston, MA" },
+    marketplace_listing_seller: { id: "seller-id", name: "Correct seller" },
+  };
+  const requestedDetails = {
+    id: "requested-id",
+    redacted_description: { text: "Correct description" },
+    condition_text: "Used - Good",
+    is_pending: true,
+    primary_listing_photo: {
+      image: { uri: "https://image.example/primary" },
+    },
+    listing_photos: [
+      { image: { uri: "https://image.example/primary" } },
+      { image: { uri: "https://image.example/second" } },
+    ],
+  };
+  const html =
+    '<script type="application/json">' +
+    JSON.stringify({ related, requestedTitle }) +
+    "</script>" +
+    '<script type="application/json">' +
+    JSON.stringify({ requestedDetails }) +
+    "</script>";
+
+  const result = parseListingDetailFromPage(html, "requested-id");
+
+  assert.equal(result.title, "Correct item");
+  assert.equal(result.price, "$42");
+  assert.equal(result.location, "Boston, MA");
+  assert.equal(result.description, "Correct description");
+  assert.equal(result.sellerName, "Correct seller");
+  assert.equal(result.seller.profileUrl, "https://www.facebook.com/seller-id");
+  assert.equal(result.condition, "Used - Good");
+  assert.equal(result.isPending, true);
+  assert.deepEqual(result.images, [
+    "https://image.example/primary",
+    "https://image.example/second",
+  ]);
+});

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -137,3 +137,77 @@ test("uses only the requested listing when page data includes related items", ()
     "https://image.example/second",
   ]);
 });
+
+test("merges array-wrapped Relay fragments linked by the product item ID", () => {
+  // Synthetic version of Facebook's script envelope; no captured page data.
+  const script = (data: unknown) =>
+    '<script type="application/json">' +
+    JSON.stringify({
+      require: [["ScheduledServerJS", "handle", null, [{
+        __bbox: { require: [["RelayPrefetchedStreamCache", "next", [], [{
+          __bbox: { result: { data } },
+        }]]] },
+      }]]],
+    }) +
+    "</script>";
+  const page = (target: unknown) => ({
+    viewer: { marketplace_product_details_page: { target } },
+  });
+  const photo = "https://image.example/desk";
+  const html =
+    script({ related: [{
+      id: "unrelated-internal-id",
+      product_item: { id: "unrelated-public-id" },
+      marketplace_listing_title: "Wrong item",
+      listing_price: { formatted_amount: "$999" },
+    }] }) +
+    // The photo fragment arrives before the fragment linking the two IDs.
+    script(page({
+      id: "internal-id",
+      listing_photos: [{ image: { uri: photo } }],
+    })) +
+    script(page({
+      id: "internal-id",
+      product_item: { id: "public-id" },
+      marketplace_listing_title: "Desk",
+      listing_price: { formatted_amount_zeros_stripped: "$42" },
+      location_text: { text: "Boston, MA" },
+      redacted_description: { text: "A small desk." },
+      marketplace_listing_seller: { id: "seller-id", name: "Example seller" },
+      creation_time: 1700000000,
+      is_pending: true,
+      attribute_data: [{
+        attribute_name: "Condition",
+        value: "used_like_new",
+        label: "Used - like new",
+      }],
+    }));
+
+  assert.deepEqual(parseListingDetailFromPage(html, "public-id"), {
+    id: "public-id",
+    title: "Desk",
+    price: "$42",
+    location: "Boston, MA",
+    description: "A small desk.",
+    imageUrl: photo,
+    images: [photo],
+    sellerName: "Example seller",
+    seller: { name: "Example seller", profileUrl: "https://www.facebook.com/seller-id" },
+    postedDate: "2023-11-14T22:13:20.000Z",
+    url: "https://www.facebook.com/marketplace/item/public-id/",
+    isPending: true,
+    condition: "Used - like new",
+  });
+
+  const missing = parseListingDetailFromPage(html, "missing-id");
+  assert.equal(missing.title, "");
+  assert.deepEqual(missing.images, []);
+});
+
+test("finds the requested listing ID directly inside JSON arrays", () => {
+  const html = '<script type="application/json">' + JSON.stringify([[
+    { id: "requested-id", marketplace_listing_title: "Desk" },
+  ]]) + "</script>";
+
+  assert.equal(parseListingDetailFromPage(html, "requested-id").title, "Desk");
+});

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -87,6 +87,96 @@ test("parses a Marketplace feed when Facebook moves the listing connection", () 
   });
 });
 
+function searchPage(edges: unknown, pageInfo: unknown = {}) {
+  return { data: { marketplace_search: { feed_units: { edges, page_info: pageInfo } } } };
+}
+
+test("distinguishes a valid empty search from missing or malformed data", () => {
+  assert.deepEqual(parseSearchResponse(searchPage([])), {
+    listings: [], hasNextPage: false, endCursor: null,
+  });
+  for (const response of [
+    null, [], {}, { data: null }, { data: [] }, { data: {} },
+    { data: { marketplace_search: { feed_units: {} } } },
+    { data: { marketplace_search: { feed_units: "invalid" } } },
+    searchPage(undefined), searchPage(null), searchPage({}), searchPage("invalid"),
+  ]) {
+    assert.throws(() => parseSearchResponse(response), /Marketplace/);
+  }
+});
+
+test("finds listing connections inside nested arrays and ignores unrelated connections", () => {
+  const connection = {
+    edges: [{ node: { listing: { id: "nested", marketplace_listing_title: "Desk" } } }],
+    page_info: { has_next_page: true, end_cursor: "cursor" },
+  };
+  const result = parseSearchResponse({ data: {
+    unrelated: { edges: [], page_info: {} },
+    other: { edges: [{ node: { id: "seller" } }] },
+    wrappers: [[null, "ignore", { payload: [connection] }]],
+  } });
+  assert.deepEqual(result.listings.map((listing) => listing.id), ["nested"]);
+  assert.equal(result.hasNextPage, true);
+  assert.equal(result.endCursor, "cursor");
+  assert.throws(() => parseSearchResponse({ data: { unrelated: { edges: [] } } }), /missing a listing connection/);
+});
+
+test("prefers the canonical connection even when it is empty", () => {
+  const response = searchPage([]);
+  Object.assign(response.data, {
+    fallback: { edges: [{ node: { id: "other", marketplace_listing_title: "Other" } }] },
+  });
+  assert.deepEqual(parseSearchResponse(response).listings, []);
+  response.data.marketplace_search.feed_units.edges = {};
+  assert.throws(() => parseSearchResponse(response), /invalid edges/);
+});
+
+test("fallback traversal terminates for cyclic objects and arrays", () => {
+  const values: unknown[] = [];
+  const data = { values };
+  values.push(data, values);
+  assert.throws(() => parseSearchResponse({ data }), /missing a listing connection/);
+  values.push({ edges: [{ node: { id: "found", marketplace_listing_title: "Desk" } }] });
+  assert.equal(parseSearchResponse({ data }).listings[0].id, "found");
+});
+
+test("keeps listings with invalid dates and preserves siblings and pagination", () => {
+  const invalidDates = ["invalid", "", null, undefined, {}, true, NaN, Infinity, 1e20];
+  const edges = invalidDates.map((creation_time, index) => ({ node: {
+    id: `invalid-date-${index}`, marketplace_listing_title: "Desk", creation_time,
+  } }));
+  const result = parseSearchResponse(searchPage([
+    ...edges,
+    { node: { listing: { id: "valid", creation_time: 1700000000 } } },
+    { node: { id: "epoch", creation_time: 0 } },
+    { node: { id: "numeric-string", creation_time: "1700000000" } },
+  ], { has_next_page: true, end_cursor: "next" }));
+  assert.equal(result.listings.length, invalidDates.length + 3);
+  assert.ok(result.listings.slice(0, invalidDates.length).every((listing) => listing.postedDate === ""));
+  assert.equal(result.listings[invalidDates.length].postedDate, "2023-11-14T22:13:20.000Z");
+  assert.equal(result.listings[invalidDates.length + 1].postedDate, "1970-01-01T00:00:00.000Z");
+  assert.equal(result.listings.at(-1)?.postedDate, "2023-11-14T22:13:20.000Z");
+  assert.equal(result.hasNextPage, true);
+  assert.equal(result.endCursor, "next");
+});
+
+test("skips malformed entries but rejects nonempty pages without usable listings", () => {
+  const malformed = [null, [], {}, { node: null }, { node: [] },
+    { node: { listing: "invalid" } }, { node: { id: {} } },
+    { node: { marketplace_listing_title: "Missing ID" } }];
+  assert.throws(() => parseSearchResponse(searchPage(malformed)), /no usable listings/);
+  const result = parseSearchResponse(searchPage([
+    ...malformed,
+    { node: { id: "good", marketplace_listing_title: "Desk" } },
+    { node: { listing: { id: 42, listing_price: { amount: 0 },
+      location: [], primary_listing_photo: "invalid", is_pending: "invalid" } } },
+  ], { has_next_page: true, end_cursor: "next" }));
+  assert.deepEqual(result.listings.map((listing) => listing.id), ["good", "42"]);
+  assert.equal(result.listings[1].price, "0");
+  assert.equal(result.listings[1].isPending, false);
+  assert.equal(result.endCursor, "next");
+});
+
 test("uses only the requested listing when page data includes related items", () => {
   const related = {
     id: "related-id",

--- a/test/raw-capture.test.ts
+++ b/test/raw-capture.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { FacebookClient } from "../src/facebook/client.js";
+import { captureListingPageHtml } from "../src/facebook/raw-capture.js";
+import type { FacebookSession } from "../src/facebook/types.js";
+
+async function withCaptureDirectory(
+  run: (directory: string) => Promise<void>,
+): Promise<void> {
+  const directory = await mkdtemp(
+    join(tmpdir(), "marketplace-raw-capture-test-"),
+  );
+  try {
+    await run(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("does not create raw captures unless explicitly enabled", async () => {
+  await withCaptureDirectory(async (directory) => {
+    const captureDirectory = join(directory, "captures");
+    await captureListingPageHtml("listing-1", "<html>private</html>", {
+      enabled: false,
+      directory: captureDirectory,
+    });
+
+    await assert.rejects(stat(captureDirectory));
+  });
+});
+
+test("writes exact opted-in HTML with owner-only permissions", async () => {
+  await withCaptureDirectory(async (directory) => {
+    const captureDirectory = join(directory, "captures");
+    const html =
+      "<html><body>c_user=private-cookie &amp; unchanged</body></html>";
+    await captureListingPageHtml("listing/1", html, {
+      enabled: true,
+      directory: captureDirectory,
+    });
+
+    const files = await readdir(captureDirectory);
+    assert.equal(files.length, 1);
+    assert.match(files[0], /listing_1/);
+    assert.equal(
+      await readFile(join(captureDirectory, files[0]), "utf8"),
+      html,
+    );
+    assert.equal((await stat(captureDirectory)).mode & 0o777, 0o700);
+    assert.equal(
+      (await stat(join(captureDirectory, files[0]))).mode & 0o777,
+      0o600,
+    );
+  });
+});
+
+test("capture failures do not change the caller's control flow", async () => {
+  await withCaptureDirectory(async (directory) => {
+    const fileInsteadOfDirectory = join(directory, "not-a-directory");
+    await writeFile(fileInsteadOfDirectory, "occupied", "utf8");
+
+    await assert.doesNotReject(
+      captureListingPageHtml("listing-1", "<html>private</html>", {
+        enabled: true,
+        directory: fileInsteadOfDirectory,
+      }),
+    );
+  });
+});
+
+test("captures a non-successful listing response before returning its error", async () => {
+  await withCaptureDirectory(async (directory) => {
+    const previousFetch = globalThis.fetch;
+    const previousCaptureEnabled = process.env.MCP_CAPTURE_LISTING_HTML;
+    const previousCaptureDirectory = process.env.MCP_LISTING_CAPTURE_DIR;
+    const html = "<html><body>Facebook login page</body></html>";
+    process.env.MCP_CAPTURE_LISTING_HTML = "1";
+    process.env.MCP_LISTING_CAPTURE_DIR = directory;
+    globalThis.fetch = (async () =>
+      new Response(html, { status: 403 })) as typeof fetch;
+
+    try {
+      const client = new FacebookClient();
+      (client as unknown as { session: FacebookSession }).session = {
+        cookies: [],
+        cookieHeader: "c_user=private-user",
+        fbDtsg: "",
+        lsd: "",
+        jazoest: "",
+        clientRevision: "",
+        userId: "private-user",
+      };
+
+      await assert.rejects(client.getListingDetail("listing-403"), /403/);
+      const files = await readdir(directory);
+      assert.equal(files.length, 1);
+      assert.equal(await readFile(join(directory, files[0]), "utf8"), html);
+    } finally {
+      globalThis.fetch = previousFetch;
+      if (previousCaptureEnabled === undefined) delete process.env.MCP_CAPTURE_LISTING_HTML;
+      else process.env.MCP_CAPTURE_LISTING_HTML = previousCaptureEnabled;
+      if (previousCaptureDirectory === undefined) {
+        delete process.env.MCP_LISTING_CAPTURE_DIR;
+      } else {
+        process.env.MCP_LISTING_CAPTURE_DIR = previousCaptureDirectory;
+      }
+    }
+  });
+});

--- a/test/search-options.test.ts
+++ b/test/search-options.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildDateListedWindow, buildSearchVariables } from "../src/facebook/queries.js";
+import { searchListingsInput } from "../src/mcp/contracts.js";
+import type { MarketplaceService } from "../src/mcp/types.js";
+import { createSearchListingsHandler } from "../src/tools/listing.js";
+
+const requiredSearch = {
+  query: "desk",
+  latitude: 42.36,
+  longitude: -71.06,
+};
+
+function browseRequest(params: Parameters<typeof buildSearchVariables>[0]) {
+  return (
+    buildSearchVariables(params) as {
+      params: { browse_request_params: Record<string, unknown> };
+    }
+  ).params.browse_request_params;
+}
+
+test("listing-search options validate with readable defaults", () => {
+  const parsed = searchListingsInput.parse(requiredSearch);
+  assert.equal(parsed.sort_by, "suggested");
+  assert.equal(parsed.delivery_method, "all");
+  assert.equal(parsed.date_listed, "all");
+  assert.throws(() =>
+    searchListingsInput.parse({ ...requiredSearch, sort_by: "best_match" }),
+  );
+  assert.throws(() =>
+    searchListingsInput.parse({ ...requiredSearch, delivery_method: "pickup" }),
+  );
+  assert.throws(() =>
+    searchListingsInput.parse({ ...requiredSearch, date_listed: "today" }),
+  );
+});
+
+test("listing-search handler forwards the new options to Marketplace", async () => {
+  let received: Parameters<MarketplaceService["searchListings"]>[0] | undefined;
+  const service: MarketplaceService = {
+    async searchListings(params) {
+      received = params;
+      return { listings: [], hasNextPage: false, endCursor: null };
+    },
+    async getListingDetail() {
+      throw new Error("not used");
+    },
+    async searchLocation() {
+      return [];
+    },
+  };
+
+  const args = searchListingsInput.parse({
+    ...requiredSearch,
+    sort_by: "price_high_to_low",
+    delivery_method: "shipping",
+    date_listed: "last_24_hours",
+  });
+  await createSearchListingsHandler(service)(args);
+
+  assert.equal(received?.sortBy, "price_high_to_low");
+  assert.equal(received?.deliveryMethod, "shipping");
+  assert.equal(received?.dateListed, "last_24_hours");
+});
+
+test("search variables reproduce captured sort and delivery mappings", () => {
+  const base = { ...requiredSearch, radiusKm: 50, limit: 20 };
+  const expectedSorts = {
+    distance: "DISTANCE_ASCEND",
+    date_listed: "CREATION_TIME_DESCEND",
+    price_low_to_high: "PRICE_ASCEND",
+    price_high_to_low: "PRICE_DESCEND",
+  } as const;
+
+  const suggested = browseRequest({ ...base, sortBy: "suggested" });
+  assert.equal(suggested.commerce_search_sort_by, undefined);
+
+  for (const [sortBy, expected] of Object.entries(expectedSorts)) {
+    const request = browseRequest({
+      ...base,
+      sortBy: sortBy as keyof typeof expectedSorts,
+    });
+    assert.equal(request.commerce_search_sort_by, expected);
+  }
+
+  assert.deepEqual(
+    [
+      "all",
+      "local_pickup",
+      "shipping",
+    ].map((deliveryMethod) => {
+      const request = browseRequest({
+        ...base,
+        deliveryMethod: deliveryMethod as "all" | "local_pickup" | "shipping",
+      });
+      return [
+        request.commerce_enable_local_pickup,
+        request.commerce_enable_shipping,
+      ];
+    }),
+    [
+      [true, true],
+      [true, false],
+      [false, true],
+    ],
+  );
+});
+
+test("date-listed filters create inclusive UTC-day windows", () => {
+  assert.equal(buildDateListedWindow("all", 20_699), null);
+  assert.equal(buildDateListedWindow("last_24_hours", 20_699), "20699;20698");
+  assert.equal(
+    buildDateListedWindow("last_7_days", 20_699),
+    "20699;20698;20697;20696;20695;20694;20693;20692",
+  );
+  assert.equal(
+    buildDateListedWindow("last_30_days", 20_699),
+    Array.from({ length: 31 }, (_, index) => String(20_699 - index)).join(";"),
+  );
+});

--- a/test/user-agent.test.ts
+++ b/test/user-agent.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { FacebookClient } from "../src/facebook/client.js";
+import { loadFacebookSession } from "../src/facebook/auth.js";
+
+const cookies = [
+  { name: "c_user", value: "test-user", domain: ".facebook.com" },
+  { name: "xs", value: "test-session", domain: ".facebook.com" },
+];
+
+test("uses saved browser identity for bootstrap, GraphQL, and listing requests", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "facebook-user-agent-"));
+  const sessionFile = join(directory, "session.json");
+  const previousFetch = globalThis.fetch;
+  const headers: Headers[] = [];
+  writeFileSync(
+    sessionFile,
+    JSON.stringify({ version: 1, cookies, userAgent: "Browser/150.0" }),
+  );
+  globalThis.fetch = async (_url, init) => {
+    headers.push(new Headers(init?.headers));
+    if (headers.length === 1)
+      return new Response('"dtsg":{"token":"test-token"}');
+    if (headers.length === 2)
+      return new Response(
+        '{"data":{"marketplace_search":{"feed_units":{"edges":[],"page_info":{"has_next_page":false}}}}}',
+      );
+    return new Response("", { status: 404 });
+  };
+  try {
+    const client = new FacebookClient({
+      sessionFile,
+      maxRequestsPerMinute: 1000,
+    });
+    await client.searchListings({
+      query: "desk",
+      latitude: 42,
+      longitude: -71,
+      radiusKm: 50,
+      limit: 1,
+    });
+    await assert.rejects(client.getListingDetail("123"), /404/);
+    assert.equal(headers.length, 3);
+    for (const header of headers) {
+      assert.equal(header.get("user-agent"), "Browser/150.0");
+      assert.equal(header.has("sec-ch-ua"), false);
+      assert.equal(header.has("sec-ch-ua-platform"), false);
+      assert.equal(header.has("sec-ch-ua-mobile"), false);
+    }
+  } finally {
+    globalThis.fetch = previousFetch;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects legacy sessions and invalid user agents before making requests", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "facebook-user-agent-"));
+  const sessionFile = join(directory, "session.json");
+  const previousFetch = globalThis.fetch;
+  try {
+    for (const content of [
+      cookies,
+      { version: 1, cookies },
+      ...["", "  ", 123, "bad\r\nInjected: value", "☃"].map((userAgent) => ({
+        version: 1,
+        cookies,
+        userAgent,
+      })),
+    ]) {
+      writeFileSync(sessionFile, JSON.stringify(content));
+      assert.throws(() => loadFacebookSession({ sessionFile }), /npm run login/);
+      globalThis.fetch = async () => { throw new Error("Unexpected request"); };
+      await assert.rejects(new FacebookClient({ sessionFile }).initSession(), /npm run login/);
+    }
+  } finally {
+    globalThis.fetch = previousFetch;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Updates authentication and the MCP tool contract, adds Marketplace search filters, and improves response parsing and diagnostics. The server now loads a session created by interactive login and reuses that browser's user agent for Facebook requests.

## What changed

- **Session authentication:** add `npm run login` using a dedicated Chrome profile; validate the Marketplace session and save cookies plus the browser user agent. Load sessions from `FACEBOOK_SESSION_FILE` or `.local/facebook-session.json`, validate required cookies and expiry, and write snapshots atomically with owner-only permissions and symlink protection.
- **MCP tools:** migrate to `registerTool` with `facebook_marketplace_` names, strict input schemas, output schemas, and tool annotations. Return structured content alongside Markdown or JSON text, expose search continuation cursors, and bound response content with truncation metadata. Separate service and monitor-store interfaces to support isolated tests.
- **Search and parsing:** update GraphQL operation IDs and request shapes; add sorting, delivery-method, and date-listed filters. Handle nested listing connections and malformed entries while preserving valid results and pagination. Resolve listing details from the requested item's embedded data and linked Relay fragments.
- **Errors and diagnostics:** reject malformed and error-only GraphQL responses, retain usable partial results, and record sanitized diagnostics with correlation IDs. Add opt-in raw listing-page HTML capture in protected local files, separate from diagnostic logs and MCP output.
- **Developer workflow:** add MCP Inspector, VS Code launch/tasks configuration, setup and troubleshooting documentation, and regression tests. Raise the documented Node.js requirement to 22+.

## Compatibility notes

- Existing integrations must update tool names to the new `facebook_marketplace_` contract. In particular, `search_location` becomes `facebook_marketplace_search_locations`, and `monitor_search` becomes `facebook_marketplace_create_monitor`.
- Run `npm run login` to generate the new session format, then restart the MCP server. Legacy cookie-only exports are rejected because the saved browser user agent is required.
- Raw HTML capture is disabled by default. Captures can contain private page data and must remain local.

## Validation

- `npm test` — all 42 tests passed.
- `npm run build` — TypeScript compilation passed.
- `git diff --check master...HEAD` — passed.
