### PR TITLE
fix: restore search results, listing field extraction, and profile lookup

### DIFF
--- a/src/facebook/auth.ts
+++ b/src/facebook/auth.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { execSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import Database from "better-sqlite3";
@@ -67,20 +68,57 @@ function decryptCookieValue(encrypted: Buffer, key: Buffer): string {
   return decoded.toString("utf8");
 }
 
-function getCookieDbPath(profile = "Default"): string {
-  return path.join(
-    os.homedir(),
-    "Library/Application Support/Google/Chrome",
-    profile,
-    "Cookies"
+const CHROME_DIR = path.join(
+  os.homedir(),
+  "Library/Application Support/Google/Chrome"
+);
+
+/**
+ * Chrome's on-disk profile directories are named "Default", "Profile 1", etc.,
+ * while the UI shows a display name ("Personal", "Work"). Accept either: if
+ * the given name isn't a directory, look it up in Chrome's Local State index.
+ */
+export function resolveChromeProfile(profile: string): string {
+  if (fs.existsSync(path.join(CHROME_DIR, profile, "Cookies"))) {
+    return profile;
+  }
+
+  let infoCache: Record<string, { name?: string }>;
+  try {
+    const localState = JSON.parse(
+      fs.readFileSync(path.join(CHROME_DIR, "Local State"), "utf8")
+    );
+    infoCache = localState?.profile?.info_cache ?? {};
+  } catch {
+    throw new Error(
+      `Chrome profile "${profile}" not found at ${CHROME_DIR} and Local State ` +
+        "could not be read to resolve it by display name."
+    );
+  }
+
+  const wanted = profile.trim().toLowerCase();
+  for (const [dir, info] of Object.entries(infoCache)) {
+    if ((info?.name ?? "").trim().toLowerCase() === wanted) return dir;
+  }
+
+  const available = Object.entries(infoCache)
+    .map(([dir, info]) => `${dir} ("${info?.name ?? "?"}")`)
+    .join(", ");
+  throw new Error(
+    `Chrome profile "${profile}" not found. CHROME_PROFILE must be a profile ` +
+      `directory name or its display name. Available: ${available || "none"}.`
   );
+}
+
+function getCookieDbPath(profile: string): string {
+  return path.join(CHROME_DIR, profile, "Cookies");
 }
 
 export function extractChromeCookies(
   domain: string,
   profile = "Default"
 ): FacebookCookie[] {
-  const cookiePath = getCookieDbPath(profile);
+  const cookiePath = getCookieDbPath(resolveChromeProfile(profile));
 
   // Chrome locks the DB while running — copy it first
   const tmpPath = path.join(os.tmpdir(), `chrome_cookies_${Date.now()}`);

--- a/src/facebook/client.ts
+++ b/src/facebook/client.ts
@@ -41,16 +41,23 @@ const BROWSER_HEADERS: Record<string, string> = {
 export class FacebookClient {
   private session: FacebookSession | null = null;
   private rateLimiter: RateLimiter;
+  private pageRateLimiter: RateLimiter;
   private reqCounter = 0;
   private chromeProfile: string;
 
   constructor(
     options: {
       maxRequestsPerMinute?: number;
+      maxPageFetchesPerMinute?: number;
       chromeProfile?: string;
     } = {}
   ) {
     this.rateLimiter = new RateLimiter(options.maxRequestsPerMinute ?? 3);
+    // Listing pages are plain document loads rather than API calls, and search
+    // hydration needs one per result, so they get a separate, higher budget.
+    this.pageRateLimiter = new RateLimiter(
+      options.maxPageFetchesPerMinute ?? 30
+    );
     this.chromeProfile = options.chromeProfile ?? "Default";
   }
 
@@ -211,7 +218,38 @@ export class FacebookClient {
   async searchListings(params: SearchParams): Promise<SearchResult> {
     const variables = buildSearchVariables(params);
     const data = await this.graphqlRequest(MARKETPLACE_SEARCH_DOC_ID, variables);
-    return parseSearchResponse(data);
+    const result = parseSearchResponse(data);
+
+    // Facebook ignores the requested `count` and returns a fixed page (~24), so
+    // enforce the limit here. This matters before hydration, which costs one
+    // page fetch per listing.
+    if (params.limit > 0 && result.listings.length > params.limit) {
+      result.listings = result.listings.slice(0, params.limit);
+      result.hasNextPage = true;
+    }
+
+    const stubs = result.listings.filter((l) => l.needsHydration);
+    if (stubs.length === 0) return result;
+
+    // The search response carried ids only, so fetch each listing page to fill
+    // in title, price, location and seller. Sequential to respect the limiter.
+    for (const stub of stubs) {
+      try {
+        const detail = await this.fetchListingPage(stub.id);
+        stub.title = detail.title;
+        stub.price = detail.price || "N/A";
+        stub.location = detail.location || "Unknown";
+        stub.sellerName = detail.sellerName || "Unknown";
+        stub.postedDate = detail.postedDate;
+        stub.imageUrl = detail.imageUrl;
+        stub.isPending = detail.isPending;
+        delete stub.needsHydration;
+      } catch {
+        // Leave the stub as-is; the id and url are still useful.
+      }
+    }
+
+    return result;
   }
 
   async getListingDetail(listingId: string): Promise<MarketplaceListingDetail> {
@@ -225,8 +263,14 @@ export class FacebookClient {
     }
 
     // Fallback: fetch the listing page directly and parse embedded data
+    return this.fetchListingPage(listingId);
+  }
+
+  private async fetchListingPage(
+    listingId: string
+  ): Promise<MarketplaceListingDetail> {
     const session = await this.ensureSession();
-    await this.rateLimiter.wait();
+    await this.pageRateLimiter.wait();
 
     const url = `https://www.facebook.com/marketplace/item/${listingId}/`;
     const res = await fetch(url, {

--- a/src/facebook/parser.ts
+++ b/src/facebook/parser.ts
@@ -20,8 +20,29 @@ export function parseSearchResponse(data: unknown): SearchResult {
 
     const listings: MarketplaceListing[] = edges
       .map((edge: any) => {
-        const listing = edge?.node?.listing;
-        if (!listing) return null;
+        const node = edge?.node;
+        const listing = node?.listing;
+
+        // The search doc_id currently returns skeleton feed units — story_key
+        // and tracking only, with no `listing` object. story_key IS the listing
+        // id, so emit a stub the client can hydrate from the listing page
+        // rather than dropping the result.
+        if (!listing) {
+          const id = node?.story_key ?? node?.top_level_post_id;
+          if (!id) return null;
+          return {
+            id: String(id),
+            title: "",
+            price: "N/A",
+            location: "Unknown",
+            imageUrl: "",
+            sellerName: "Unknown",
+            postedDate: "",
+            url: `https://www.facebook.com/marketplace/item/${id}/`,
+            isPending: false,
+            needsHydration: true,
+          };
+        }
 
         return {
           id: listing.id ?? "",
@@ -59,9 +80,6 @@ export function parseListingDetailFromPage(
   html: string,
   listingId: string
 ): MarketplaceListingDetail {
-  // Facebook embeds listing data as JSON in script tags.
-  // Look for structured data or relay-style data payloads.
-
   const detail: MarketplaceListingDetail = {
     id: listingId,
     title: "",
@@ -78,64 +96,164 @@ export function parseListingDetailFromPage(
     seller: { name: "", profileUrl: "" },
   };
 
-  // Try to extract from meta tags first (most reliable)
-  const titleMatch = html.match(
-    /<meta\s+property="og:title"\s+content="([^"]*)"/
-  );
-  if (titleMatch) detail.title = decodeHtmlEntities(titleMatch[1]);
+  // Facebook serves og: meta tags only to logged-out requests. For an
+  // authenticated session the listing data is in the embedded Relay payload,
+  // where the target listing is the first occurrence of each field (later ones
+  // belong to the "related items" rail). Meta tags stay as a fallback.
+  detail.title =
+    matchJsonString(html, /"marketplace_listing_title"\s*:\s*"((?:[^"\\]|\\.)*)"/) ??
+    matchJsonString(html, /"custom_title"\s*:\s*"((?:[^"\\]|\\.)*)"/) ??
+    metaTag(html, "og:title") ??
+    "";
 
-  const descMatch = html.match(
-    /<meta\s+property="og:description"\s+content="([^"]*)"/
-  );
-  if (descMatch) detail.description = decodeHtmlEntities(descMatch[1]);
+  detail.description =
+    matchJsonString(
+      html,
+      /"redacted_description"\s*:\s*\{\s*"text"\s*:\s*"((?:[^"\\]|\\.)*)"/
+    ) ??
+    matchJsonString(html, /"listing_description"\s*:\s*"((?:[^"\\]|\\.)*)"/) ??
+    metaTag(html, "og:description") ??
+    "";
 
-  const imageMatch = html.match(
-    /<meta\s+property="og:image"\s+content="([^"]*)"/
-  );
-  if (imageMatch) {
-    detail.imageUrl = decodeHtmlEntities(imageMatch[1]);
-    detail.images.push(detail.imageUrl);
+  // listing_price carries a display string plus raw amount/currency. Prefer the
+  // preformatted string; fall back to composing one.
+  const priceBlob = html.match(/"listing_price"\s*:\s*\{[^}]*\}/);
+  if (priceBlob) {
+    const blob = priceBlob[0];
+    const formatted =
+      matchJsonString(blob, /"formatted_amount_zeros_stripped"\s*:\s*"([^"]*)"/) ??
+      matchJsonString(blob, /"formatted_amount"\s*:\s*"([^"]*)"/);
+    const amount = matchJsonString(blob, /"amount"\s*:\s*"([^"]*)"/);
+    const currency = matchJsonString(blob, /"currency"\s*:\s*"([^"]*)"/);
+
+    detail.price =
+      formatted ??
+      (amount ? [amount, currency].filter(Boolean).join(" ") : "");
   }
 
-  // Try to extract price from embedded JSON
-  const priceMatch =
-    html.match(/"formatted_amount"\s*:\s*"([^"]+)"/) ??
-    html.match(/"price"\s*:\s*"([^"]+)"/) ??
-    html.match(/\"amount\"\s*:\s*"([^"]+)"/);
-  if (priceMatch) detail.price = priceMatch[1];
+  detail.location =
+    matchJsonString(
+      html,
+      /"location_text"\s*:\s*\{\s*"text"\s*:\s*"((?:[^"\\]|\\.)*)"/
+    ) ??
+    matchJsonString(html, /"reverse_geocode_city"\s*:\s*"((?:[^"\\]|\\.)*)"/) ??
+    "";
 
-  // Extract additional images
-  const imageRegex = /marketplace_listing_photos.*?"uri"\s*:\s*"([^"]+)"/g;
-  let imgMatch;
-  while ((imgMatch = imageRegex.exec(html)) !== null) {
-    const url = imgMatch[1].replace(/\\\//g, "/");
-    if (!detail.images.includes(url)) {
-      detail.images.push(url);
-    }
+  const seller =
+    matchJsonString(
+      html,
+      /"marketplace_listing_seller"\s*:\s*\{[^{]*?"name"\s*:\s*"((?:[^"\\]|\\.)*)"/
+    ) ??
+    matchJsonString(
+      html,
+      /"story_seller"\s*:\s*\{[^{]*?"name"\s*:\s*"((?:[^"\\]|\\.)*)"/
+    );
+  if (seller) {
+    detail.sellerName = seller;
+    detail.seller.name = seller;
   }
 
-  // Extract seller name
-  const sellerMatch = html.match(
-    /"marketplace_listing_seller"\s*:\s*\{[^}]*"name"\s*:\s*"([^"]+)"/
-  );
-  if (sellerMatch) {
-    detail.sellerName = sellerMatch[1];
-    detail.seller.name = sellerMatch[1];
+  const creationTime = html.match(/"creation_time"\s*:\s*(\d+)/);
+  if (creationTime) {
+    detail.postedDate = new Date(Number(creationTime[1]) * 1000).toISOString();
   }
 
-  // Extract condition
-  const conditionMatch = html.match(
-    /"condition_text"\s*:\s*"([^"]+)"/
-  ) ?? html.match(/"condition"\s*:\s*"([^"]+)"/);
-  if (conditionMatch) detail.condition = conditionMatch[1];
+  // Condition is exposed as a localized attribute, e.g.
+  // "attribute_data":[{"attribute_name":"\u00c9tat","value":"new","label":"Neuf"}].
+  // The bare /"condition":"..."/ pattern used previously matched unrelated
+  // Relay keys, so key off attribute_data and prefer its display label.
+  detail.condition =
+    matchJsonString(
+      html,
+      /"attribute_data"\s*:\s*\[\s*\{[^}]*?"label"\s*:\s*"((?:[^"\\]|\\.)*)"/
+    ) ??
+    matchJsonString(
+      html,
+      /"attribute_data"\s*:\s*\[\s*\{[^}]*?"value"\s*:\s*"((?:[^"\\]|\\.)*)"/
+    ) ??
+    matchJsonString(html, /"condition_text"\s*:\s*"((?:[^"\\]|\\.)*)"/) ??
+    "";
 
-  // Extract location
-  const locationMatch = html.match(
-    /"location_text"\s*:\s*\{[^}]*"text"\s*:\s*"([^"]+)"/
-  ) ?? html.match(/"reverse_geocode_city"\s*:\s*"([^"]+)"/);
-  if (locationMatch) detail.location = locationMatch[1];
+  detail.isPending = /"is_pending"\s*:\s*true/.test(html);
+
+  const primaryPhoto =
+    matchJsonString(
+      html,
+      /"primary_listing_photo"\s*:\s*\{[^{]*?"uri"\s*:\s*"([^"]+)"/
+    ) ?? metaTag(html, "og:image");
+  if (primaryPhoto) {
+    detail.imageUrl = primaryPhoto;
+    detail.images.push(primaryPhoto);
+  }
+
+  // listing_photos is an array of { image: { uri } }, so collect every uri
+  // inside the array rather than just the first.
+  for (const uri of extractPhotoUris(html)) {
+    if (!detail.images.includes(uri)) detail.images.push(uri);
+  }
 
   return detail;
+}
+
+function metaTag(html: string, property: string): string | null {
+  const m = html.match(
+    new RegExp(`<meta\\s+property="${property}"\\s+content="([^"]*)"`)
+  );
+  return m ? decodeHtmlEntities(m[1]) : null;
+}
+
+function matchJsonString(html: string, re: RegExp): string | null {
+  const m = html.match(re);
+  return m ? unescapeJsonString(m[1]) : null;
+}
+
+/**
+ * The Relay payload is JSON embedded in HTML, so values arrive double-escaped:
+ * \uXXXX for non-ASCII (Arabic place names, emoji), \n, \/ and \".
+ */
+function unescapeJsonString(str: string): string {
+  return str
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) =>
+      String.fromCharCode(parseInt(hex, 16))
+    )
+    .replace(/\\n/g, "\n")
+    .replace(/\\t/g, "\t")
+    .replace(/\\r/g, "")
+    .replace(/\\\//g, "/")
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, "\\");
+}
+
+function extractPhotoUris(html: string): string[] {
+  const key = '"listing_photos":[';
+  const start = html.indexOf(key);
+  if (start === -1) return [];
+
+  // Walk the bracket depth to find the end of the array instead of guessing a
+  // window size, since a listing can carry many large photo objects.
+  let depth = 0;
+  let end = -1;
+  for (let i = start + key.length - 1; i < html.length; i++) {
+    const ch = html[i];
+    if (ch === "[") depth++;
+    else if (ch === "]") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) return [];
+
+  const block = html.slice(start, end);
+  const uris: string[] = [];
+  const re = /"uri"\s*:\s*"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(block)) !== null) {
+    uris.push(unescapeJsonString(m[1]));
+  }
+  return uris;
 }
 
 function decodeHtmlEntities(str: string): string {

--- a/src/facebook/types.ts
+++ b/src/facebook/types.ts
@@ -28,6 +28,8 @@ export interface MarketplaceListing {
   postedDate: string;
   url: string;
   isPending: boolean;
+  /** Set when the search response lacked listing fields and only an id was recoverable. */
+  needsHydration?: boolean;
 }
 
 export interface MarketplaceListingDetail extends MarketplaceListing {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,10 @@ import {
 } from "./tools/monitor.js";
 
 const client = new FacebookClient({
-  maxRequestsPerMinute: 3,
+  maxRequestsPerMinute: Number(process.env.MAX_REQUESTS_PER_MINUTE ?? 3),
+  maxPageFetchesPerMinute: Number(
+    process.env.MAX_PAGE_FETCHES_PER_MINUTE ?? 30
+  ),
   chromeProfile: process.env.CHROME_PROFILE ?? "Default",
 });
 


### PR DESCRIPTION
The search doc_id still responds, but its feed units now carry only story_key, tracking and id — the listing object with the title, price and seller is gone, so parseSearchResponse was dropping every edge.

story_key is the listing id, so emit a stub and hydrate it from the listing page. Searches go from 0 to 24 results. The fast path is untouched: re-capturing a fresh doc_id stops the fallback from triggering. The same bug was silently breaking check_monitors, which diffs on listing id and so could never fire.

Three things found while testing that:

- parseListingDetailFromPage read og: meta tags, which Facebook only serves to logged-out requests, so titles and descriptions were always empty for a real session. Reads the Relay payload instead, with the meta tags kept as fallback. Photo extraction anchored on "listing_photos" once and returned only the primary image, and condition was read from two keys that don't exist on the page (it lives in attribute_data).

- limit was ignored, since Facebook returns a fixed ~24-result page regardless of count. Matters here because limit: 5 was fetching 24 listing pages during hydration.

- CHROME_PROFILE only accepted directory names, so setting it to the profile name Chrome actually shows you failed with a missing-file error. Accepts either now.

Listing pages get their own rate-limit budget, since the shared 3/min would make a single 24-result search take eight minutes. Configurable via MAX_PAGE_FETCHES_PER_MINUTE.